### PR TITLE
Adding git-secrets to repo

### DIFF
--- a/.github/workflows/git-secret.yaml
+++ b/.github/workflows/git-secret.yaml
@@ -1,0 +1,22 @@
+name: Scanning Code For Secrets
+
+on: [pull_request]
+
+jobs:
+  git-secrets-check:
+    name: Run git-secrets scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup git-secrets
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git
+          cd git-secrets
+          sudo make install
+          cd ..
+          git-secrets --register-aws
+      - name: Scan for secrets
+        run: |
+          git-secrets --scan-history


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a `git-secrets` scan to the PR workflow.  This will scan the repo and use a regex to match any common credentials or secrets and flag them in the approval workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Example of failed GitHub workflow due to `git-secrets` failure: https://github.com/amazon-connect/amazon-connect-chat-android/actions/runs/10049034263
