### PR TITLE
Implementing sendAttachment flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:name=".ChatApplication"

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
@@ -1,6 +1,9 @@
 package com.amazon.connect.chat.androidchatexample.viewmodel
 
+import android.app.Activity
+import android.content.Intent
 import android.content.SharedPreferences
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -368,4 +371,22 @@ class ChatViewModel @Inject constructor(
         _errorMessage.value = null
     }
 
+    // Request code for selecting a PDF document.
+    val PICK_PDF_FILE = 2
+
+    fun openFile(activity: Activity) {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+        }
+
+        activity.startActivityForResult(intent, PICK_PDF_FILE)
+    }
+
+
+    fun uploadAttachment(fileUri: Uri) {
+        viewModelScope.launch {
+            chatSession.sendAttachment(fileUri)
+        }
+    }
 }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -1,5 +1,6 @@
 package com.amazon.connect.chat.sdk
 
+import android.net.Uri
 import com.amazon.connect.chat.sdk.model.ChatDetails
 import com.amazon.connect.chat.sdk.model.ChatEvent
 import com.amazon.connect.chat.sdk.model.GlobalConfig
@@ -33,6 +34,12 @@ interface ChatSession {
      * @return True if a chat session is active, false otherwise.
      */
     var onChatSessionStateChanged: ((Boolean) -> Unit)?
+
+    /**
+     * Sends an attachment.
+     * @return A Result indicating whether sending the attachment was successful.
+     */
+    suspend fun sendAttachment(fileUri: Uri): Result<Unit>
 
     var onConnectionEstablished: (() -> Unit)?
     var onConnectionReEstablished: (() -> Unit)?
@@ -143,5 +150,16 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
         transcriptCollectionJob = null
         transcriptListCollectionJob = null
         chatSessionStateCollectionJob = null
+    }
+    
+    override suspend fun sendAttachment(fileUri: Uri): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                chatService.sendAttachment(fileUri)
+                Result.success(Unit)
+            }.getOrElse {
+                Result.failure(it)
+            }
+        }
     }
 }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/di/ChatModule.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/di/ChatModule.kt
@@ -3,8 +3,8 @@ package com.amazon.connect.chat.sdk.di
 import android.content.Context
 import com.amazon.connect.chat.sdk.ChatSession
 import com.amazon.connect.chat.sdk.ChatSessionImpl
-import com.amazon.connect.chat.sdk.network.APIClient
 import com.amazon.connect.chat.sdk.network.AWSClient
+import com.amazon.connect.chat.sdk.network.AttachmentsManager
 import com.amazon.connect.chat.sdk.network.WebSocketManager
 import com.amazon.connect.chat.sdk.network.MetricsManager
 import com.amazon.connect.chat.sdk.network.NetworkConnectionManager
@@ -39,9 +39,10 @@ object ChatModule {
         awsClient: AWSClient,
         connectionDetailsProvider: ConnectionDetailsProvider,
         webSocketManager: WebSocketManager,
-        metricsManager: MetricsManager
+        metricsManager: MetricsManager,
+        attachmentsManager: AttachmentsManager
     ): ChatService {
-        return ChatServiceImpl(awsClient, connectionDetailsProvider, webSocketManager, metricsManager)
+        return ChatServiceImpl(awsClient, connectionDetailsProvider, webSocketManager, metricsManager, attachmentsManager)
     }
 
     /**

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/di/NetworkModule.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/di/NetworkModule.kt
@@ -5,9 +5,11 @@ import com.amazon.connect.chat.sdk.network.APIClient
 import com.amazon.connect.chat.sdk.network.AWSClient
 import com.amazon.connect.chat.sdk.network.AWSClientImpl
 import com.amazon.connect.chat.sdk.network.ApiUrl
+import com.amazon.connect.chat.sdk.network.AttachmentsInterface
 import com.amazon.connect.chat.sdk.network.MetricsInterface
 import com.amazon.connect.chat.sdk.network.MetricsManager
 import com.amazon.connect.chat.sdk.network.NetworkConnectionManager
+import com.amazon.connect.chat.sdk.network.AttachmentsManager
 import com.amazon.connect.chat.sdk.utils.MetricsUtils.getMetricsEndpoint
 import com.amazonaws.services.connectparticipant.AmazonConnectParticipantClient
 import dagger.Module
@@ -76,6 +78,30 @@ object NetworkModule {
     }
 
     /**
+     * Provides a singleton instance of MetricsInterface.
+     *
+     * @param retrofitBuilder The Retrofit.Builder instance for creating the service.
+     * @return An instance of MetricsInterface.
+     */
+    @Provides
+    @Singleton
+    fun provideAttachmentsManager(context: Context, awsClient: AWSClient, apiClient: APIClient): AttachmentsManager {
+        return AttachmentsManager(context, awsClient, apiClient)
+    }
+
+    /**
+     * Provides a singleton instance of AttachmentsInterface.
+     *
+     * @param retrofitBuilder The Retrofit.Builder instance for creating the service.
+     * @return An instance of MetricsInterface.
+     */
+    @Provides
+    @Singleton
+    fun provideAttachmentsInterface(retrofitBuilder: Retrofit.Builder): AttachmentsInterface {
+        return createService(AttachmentsInterface::class.java, retrofitBuilder)
+    }
+
+    /**
      * Provides a singleton instance of AmazonConnectParticipantClient.
      *
      * @return An instance of AmazonConnectParticipantClient.
@@ -106,8 +132,8 @@ object NetworkModule {
      */
     @Provides
     @Singleton
-    fun provideAPIClient(metricsInterface: MetricsInterface): APIClient {
-        return APIClient(metricsInterface)
+    fun provideAPIClient(metricsInterface: MetricsInterface, attachmentsInterface: AttachmentsInterface): APIClient {
+        return APIClient(metricsInterface, attachmentsInterface)
     }
 
     /**

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/GlobalConfig.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/GlobalConfig.kt
@@ -5,7 +5,9 @@ import com.amazonaws.regions.Regions
 
 data class GlobalConfig(
     var region: Regions = defaultRegion,
-    var features: Features = Features.defaultFeatures
+    var features: Features = Features.defaultFeatures,
+    var disableCsm: Boolean = false,
+    var isDevMode: Boolean = false
 ) {
     companion object {
         val defaultRegion: Regions

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/APIClient.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/APIClient.kt
@@ -1,14 +1,18 @@
 package com.amazon.connect.chat.sdk.network
 
 import com.amazon.connect.chat.sdk.model.MetricRequestBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.asRequestBody
 import retrofit2.Call
 import retrofit2.Callback
 
 import retrofit2.Response
+import java.io.File
 import javax.inject.Inject
 
 class APIClient @Inject constructor(
-    private val metricsInterface: MetricsInterface
+    private val metricsInterface: MetricsInterface,
+    private val attachmentsInterface: AttachmentsInterface
 ) {
     fun sendMetrics(metricRequestBody: MetricRequestBody, callback: (Response<Any>?) -> Unit) {
         val call = metricsInterface.sendMetrics(metricRequestBody)
@@ -22,6 +26,24 @@ class APIClient @Inject constructor(
             }
 
             override fun onFailure(call: Call<Any>, t: Throwable) {
+                callback(null)
+            }
+        })
+    }
+
+    fun uploadAttachment(url: String, headerMap: Map<String, String>, inputStream: File, callback: (Response<Unit>?) -> Unit) {
+        val requestBody = inputStream.asRequestBody("application/octet-stream".toMediaTypeOrNull())
+        val call = attachmentsInterface.uploadAttachment(url, requestBody, headerMap)
+
+        call.enqueue(object: Callback<Unit> {
+            override fun onResponse(
+                call: Call<Unit>,
+                response: Response<Unit>
+            ) {
+                callback(response)
+            }
+
+            override fun onFailure(call: Call<Unit>, t: Throwable) {
                 callback(null)
             }
         })

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AWSClient.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AWSClient.kt
@@ -6,9 +6,13 @@ import com.amazon.connect.chat.sdk.utils.Constants
 import com.amazon.connect.chat.sdk.model.GlobalConfig
 import com.amazonaws.regions.Region
 import com.amazonaws.services.connectparticipant.AmazonConnectParticipantClient
+import com.amazonaws.services.connectparticipant.model.CompleteAttachmentUploadRequest
+import com.amazonaws.services.connectparticipant.model.CompleteAttachmentUploadResult
 import com.amazonaws.services.connectparticipant.model.CreateParticipantConnectionRequest
 import com.amazonaws.services.connectparticipant.model.DisconnectParticipantRequest
 import com.amazonaws.services.connectparticipant.model.DisconnectParticipantResult
+import com.amazonaws.services.connectparticipant.model.StartAttachmentUploadRequest
+import com.amazonaws.services.connectparticipant.model.StartAttachmentUploadResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -28,6 +32,10 @@ interface AWSClient {
      * @return A Result containing the disconnect participant result if successful, or an exception if an error occurred.
      */
     suspend fun disconnectParticipantConnection(connectionToken: String): Result<DisconnectParticipantResult>
+
+    suspend fun startAttachmentUpload(connectionToken: String, request: StartAttachmentUploadRequest): Result<StartAttachmentUploadResult>
+
+    suspend fun completeAttachmentUpload(connectionToken: String, request: CompleteAttachmentUploadRequest): Result<CompleteAttachmentUploadResult>
 }
 
 class AWSClientImpl @Inject constructor(
@@ -65,6 +73,26 @@ class AWSClientImpl @Inject constructor(
                 }
                 val response = connectParticipantClient.disconnectParticipant(request)
                 Log.d("AWSClientImpl", "disconnectParticipantConnection: $response")
+                response
+            }
+        }
+    }
+
+    override suspend fun startAttachmentUpload(connectionToken: String, request: StartAttachmentUploadRequest): Result<StartAttachmentUploadResult> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                val response = connectParticipantClient.startAttachmentUpload(request)
+                Log.d("AWSClientImpl", "startAttachmentUpload: $response")
+                response
+            }
+        }
+    }
+
+    override suspend fun completeAttachmentUpload(connectionToken: String, request: CompleteAttachmentUploadRequest): Result<CompleteAttachmentUploadResult> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                val response = connectParticipantClient.completeAttachmentUpload(request)
+                Log.d("AWSClientImpl", "completeAttachmentUpload: $response")
                 response
             }
         }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsInterface.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsInterface.kt
@@ -1,0 +1,14 @@
+package com.amazon.connect.chat.sdk.network
+
+import okhttp3.RequestBody
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.HeaderMap
+import retrofit2.http.PUT
+import retrofit2.http.Url
+
+interface AttachmentsInterface {
+
+    @PUT
+    fun uploadAttachment(@Url url: String, @Body file: RequestBody, @HeaderMap headers: Map<String, String>): Call<Unit>
+}

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
@@ -1,0 +1,133 @@
+package com.amazon.connect.chat.sdk.network
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import javax.inject.Inject
+import java.util.*
+import com.amazon.connect.chat.sdk.utils.Constants
+import com.amazonaws.services.connectparticipant.model.CompleteAttachmentUploadRequest
+import com.amazonaws.services.connectparticipant.model.StartAttachmentUploadRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+class AttachmentsManager @Inject constructor(
+    private val context: Context,
+    private val awsClient: AWSClient,
+    private var apiClient: APIClient
+) {
+
+    suspend fun sendAttachment(connectionToken: String, fileUri: Uri) {
+        val startAttachmentUploadRequest = createStartAttachmentUploadRequest(connectionToken, fileUri)
+        val fileExtension = getFileExtension(startAttachmentUploadRequest.attachmentName)
+        if (!Constants.attachmentTypeMap.containsKey(fileExtension)) {
+            Log.d("AttachmentsManager", "Unsupported file type: $fileExtension")
+            return
+        }
+        val startAttachmentResult = awsClient.startAttachmentUpload(connectionToken, startAttachmentUploadRequest)
+        val startAttachmentResponse = startAttachmentResult.getOrNull()
+        if (startAttachmentResponse == null) {
+            val exception = startAttachmentResult.exceptionOrNull()
+            println("Error occurred: ${exception?.message}")
+            return
+        }
+        val attachmentId = startAttachmentResponse.attachmentId
+        val file = fileFromContentUri(fileUri, fileExtension)
+        apiClient.uploadAttachment(startAttachmentResponse.uploadMetadata.url, startAttachmentResponse.uploadMetadata.headersToInclude, file) { response ->
+            CoroutineScope(Dispatchers.IO).launch {
+                if (response != null && response.isSuccessful) {
+                    completeAttachmentUpload(connectionToken, attachmentId)
+                } else {
+                    val exception = response?.message()
+                    println("Error occurred: $exception")
+                }
+                file.deleteRecursively()
+            }
+        }
+    }
+
+    suspend fun completeAttachmentUpload(connectionToken: String, attachmentId: String) {
+        val request = CompleteAttachmentUploadRequest().apply {
+            this.connectionToken = connectionToken
+            this.setAttachmentIds(listOf(attachmentId))
+        }
+        val completeAttachmentUploadResult = awsClient.completeAttachmentUpload(connectionToken, request)
+
+        val completeAttachmentUploadResponse = completeAttachmentUploadResult.getOrNull()
+        if (completeAttachmentUploadResponse == null) {
+            val exception = completeAttachmentUploadResult.exceptionOrNull()
+            println("Error occurred: ${exception?.message}")
+            return
+        }
+    }
+
+    fun createStartAttachmentUploadRequest(connectionToken: String, fileUri: Uri): StartAttachmentUploadRequest {
+        var attachmentName: String? = null
+        var attachmentSize: Long? = null
+        val contentType = context.contentResolver.getType(fileUri)
+
+        context.contentResolver.query(fileUri, null, null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+
+                if (nameIndex != -1) {
+                    attachmentName = cursor.getString(nameIndex)
+                }
+                if (sizeIndex != -1) {
+                    attachmentSize = cursor.getLong(sizeIndex)
+                }
+            }
+        }
+        val request = StartAttachmentUploadRequest().apply {
+            this.connectionToken = connectionToken
+            this.attachmentName = attachmentName
+            this.contentType = contentType
+            this.attachmentSizeInBytes = attachmentSize
+        }
+        return request
+    }
+
+    fun fileFromContentUri(contentUri: Uri, fileExtension: String?): File {
+
+        val fileName = "temp_file" + if (fileExtension != null) ".$fileExtension" else ""
+
+        val tempFile = File(context.cacheDir, fileName)
+        tempFile.createNewFile()
+        try {
+            val outputStream = FileOutputStream(tempFile)
+            val inputStream = context.contentResolver.openInputStream(contentUri)
+
+            inputStream?.let {
+                copy(inputStream, outputStream)
+            }
+
+            outputStream.flush()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        return tempFile
+    }
+
+    fun getFileExtension(filename: String): String? {
+        val fileExtensionRegex = """[^.]+$""".toRegex()
+        return fileExtensionRegex.find(filename)?.value
+    }
+
+    @Throws(IOException::class)
+    private fun copy(source: InputStream, target: OutputStream) {
+        val buf = ByteArray(8192)
+        var length: Int
+        while (source.read(buf).also { length = it } > 0) {
+            target.write(buf, 0, length)
+        }
+    }
+}

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/Constants.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/Constants.kt
@@ -28,4 +28,23 @@ object Constants {
             return "Failed to create connection: $reason."
         }
     }
+
+    val attachmentTypeMap = mapOf(
+        "csv" to "text/csv",
+        "doc" to "application/msword",
+        "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "heic" to "image/heic",
+        "jpg" to "image/jpeg",
+        "mov" to "video/quicktime",
+        "mp4" to "video/mp4",
+        "pdf" to "application/pdf",
+        "png" to "image/png",
+        "ppt" to "application/vnd.ms-powerpoint",
+        "pptx" to "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "rtf" to "application/rtf",
+        "txt" to "text/plain",
+        "wav" to "audio/wav",
+        "xls" to "application/vnd.ms-excel",
+        "xlsx" to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
 }

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/network/AttachmentsManagerTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/network/AttachmentsManagerTest.kt
@@ -1,0 +1,207 @@
+package com.amazon.connect.chat.sdk.network
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import com.amazon.connect.chat.sdk.utils.Constants
+import com.amazonaws.services.connectparticipant.AmazonConnectParticipantClient
+import com.amazonaws.services.connectparticipant.model.CompleteAttachmentUploadRequest
+import com.amazonaws.services.connectparticipant.model.CompleteAttachmentUploadResult
+import com.amazonaws.services.connectparticipant.model.StartAttachmentUploadRequest
+import com.amazonaws.services.connectparticipant.model.StartAttachmentUploadResult
+import com.amazonaws.services.connectparticipant.model.UploadMetadata
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.Response
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.Mock
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.anyOrNull
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import retrofit2.Response as RetrofitResponse
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class AttachmentsManagerTest {
+
+    @Mock
+    private lateinit var mockClient: AmazonConnectParticipantClient
+
+    @Mock
+    private lateinit var attachmentsInterface: AttachmentsInterface
+
+    @Mock
+    private lateinit var metricsInterface: MetricsInterface
+
+    private lateinit var awsClient: AWSClientImpl
+    private lateinit var apiClient: APIClient
+    private lateinit var attachmentsManager: AttachmentsManager
+
+    private val context = mock(Context::class.java)
+    private val contentResolver = mock(ContentResolver::class.java)
+    private val mockStartAttachmentUploadRequest = StartAttachmentUploadRequest()
+    private val mockStartAttachmentUploadResult = StartAttachmentUploadResult()
+
+    private val mockUri: Uri = Uri.parse("https://example.com/dummy")
+    private val mockAttachmentId = "12345"
+    private val mockUploadMetadata = UploadMetadata()
+    private val mockUrl = "https://example.com/"
+    private val mockHeadersToInclude = mapOf("key1" to "value1", "key2" to "value2", "key3" to "value3")
+    private val mockConnectionToken = "connectionToken"
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        awsClient = spy(AWSClientImpl(mockClient))
+        apiClient = spy(APIClient(metricsInterface, attachmentsInterface))
+        `when`(context.contentResolver).thenReturn(contentResolver)
+        mockStartAttachmentUploadRequest.apply {
+            this.connectionToken = mockConnectionToken
+            this.attachmentName = "example.txt"
+            this.contentType = "text/plain"
+            this.attachmentSizeInBytes = 1000
+        }
+        mockUploadMetadata.apply {
+            this.url = mockUrl
+            this.headersToInclude = mockHeadersToInclude
+        }
+        mockStartAttachmentUploadResult.apply {
+            this.attachmentId = mockAttachmentId
+            this.uploadMetadata = mockUploadMetadata
+        }
+        attachmentsManager = spy(AttachmentsManager(context, awsClient, apiClient))
+    }
+
+    @Test
+    fun test_sendAttachment_success() = runTest {
+        doReturn(mockStartAttachmentUploadRequest)
+            .`when`(attachmentsManager)
+            .createStartAttachmentUploadRequest(mockConnectionToken, mockUri)
+
+        doReturn(mockStartAttachmentUploadResult)
+            .`when`(awsClient)
+            .startAttachmentUpload(mockConnectionToken, mockStartAttachmentUploadRequest)
+
+        doReturn(Unit).`when`(attachmentsManager).completeAttachmentUpload(mockConnectionToken, mockAttachmentId)
+
+        doAnswer { invocation ->
+            val callback = invocation.getArgument<((RetrofitResponse<*>?) -> Unit)>(3)
+            val mockResponse = mock(RetrofitResponse::class.java)
+            `when`(mockResponse.isSuccessful).thenReturn(true)
+            callback(mockResponse)
+            null
+        }.`when`(apiClient).uploadAttachment(anyString(), anyMap(), anyOrNull(), anyOrNull())
+
+        attachmentsManager.sendAttachment(mockConnectionToken, mockUri)
+        verify(awsClient).startAttachmentUpload(anyString(), anyOrNull())
+        verify(apiClient).uploadAttachment(anyString(), anyMap(), anyOrNull(), anyOrNull())
+        verify(attachmentsManager).completeAttachmentUpload(mockConnectionToken, mockAttachmentId)
+    }
+
+    @Test
+    fun test_sendAttachment_uploadAttachmentFailure() = runTest {
+        doReturn(mockStartAttachmentUploadRequest)
+            .`when`(attachmentsManager)
+            .createStartAttachmentUploadRequest(mockConnectionToken, mockUri)
+
+        doReturn(mockStartAttachmentUploadResult)
+            .`when`(awsClient)
+            .startAttachmentUpload(mockConnectionToken, mockStartAttachmentUploadRequest)
+
+        doAnswer { invocation ->
+            val callback = invocation.getArgument<((Response?) -> Unit)>(3)
+            callback(null)
+            null
+        }.`when`(apiClient).uploadAttachment(anyString(), anyMap(), anyOrNull(), anyOrNull())
+
+        attachmentsManager.sendAttachment(mockConnectionToken, mockUri)
+        verify(awsClient).startAttachmentUpload(anyString(), anyOrNull())
+        verify(apiClient).uploadAttachment(anyString(), anyMap(), anyOrNull(), anyOrNull())
+        verify(attachmentsManager, never()).completeAttachmentUpload(anyString(), anyString())
+    }
+
+    @Test
+    fun test_sendAttachment_startAttachmentUploadFailure() = runTest {
+        doReturn(mockStartAttachmentUploadRequest)
+            .`when`(attachmentsManager)
+            .createStartAttachmentUploadRequest(mockConnectionToken, mockUri)
+
+        doReturn(null)
+            .`when`(awsClient)
+            .startAttachmentUpload(mockConnectionToken, mockStartAttachmentUploadRequest)
+
+        attachmentsManager.sendAttachment(mockConnectionToken, mockUri)
+        verify(apiClient, never()).uploadAttachment(anyString(), anyMap(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun test_sendAttachment_invalidType() = runTest {
+        mockStartAttachmentUploadRequest.apply {
+            this.attachmentName = "example.asdf"
+        }
+        doReturn(mockStartAttachmentUploadRequest)
+            .`when`(attachmentsManager)
+            .createStartAttachmentUploadRequest(mockConnectionToken, mockUri)
+        attachmentsManager.sendAttachment(mockConnectionToken, mockUri)
+        verify(awsClient, never()).startAttachmentUpload(anyString(), anyOrNull())
+    }
+
+    @Test
+    fun test_fileFromContentUri() = runTest {
+        val mockCacheDir = File("test/cache")
+        mockCacheDir.mkdirs()
+        val tempFile = File(mockCacheDir, "example.txt")
+        tempFile.createNewFile()
+        tempFile.writeText("Write test file content")
+        val testInputStream: InputStream = FileInputStream(tempFile)
+        `when`(context.cacheDir).thenReturn(mockCacheDir)
+        `when`(contentResolver.openInputStream(mockUri)).thenReturn(testInputStream)
+        val copiedFile = attachmentsManager.fileFromContentUri(mockUri, "txt")
+        assertTrue(copiedFile.isFile)
+        assertTrue(copiedFile.path == "test/cache/temp_file.txt")
+        assertTrue(copiedFile.length() == tempFile.length())
+        File("test").deleteRecursively()
+    }
+
+    @Test
+    fun test_getFileExtension() = runTest {
+        for (extension in Constants.attachmentTypeMap.keys) {
+            val fileExtension = attachmentsManager.getFileExtension("example.$extension")
+            assertTrue(fileExtension == extension)
+        }
+    }
+
+    @Test
+    fun test_completeAttachmentUpload() = runTest {
+        val mockCompleteAttachmentUploadRequest = CompleteAttachmentUploadRequest()
+        mockCompleteAttachmentUploadRequest.setAttachmentIds(listOf(mockAttachmentId))
+        mockCompleteAttachmentUploadRequest.apply {
+            this.connectionToken = mockConnectionToken
+        }
+
+        val mockCompleteAttachmentUploadResult = CompleteAttachmentUploadResult()
+
+        doReturn(mockCompleteAttachmentUploadResult)
+            .`when`(awsClient)
+            .completeAttachmentUpload(mockConnectionToken, mockCompleteAttachmentUploadRequest)
+
+        attachmentsManager.completeAttachmentUpload(mockConnectionToken, mockAttachmentId)
+
+        verify(awsClient).completeAttachmentUpload(mockConnectionToken, mockCompleteAttachmentUploadRequest)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR implements the `sendAttachment` flow.  Here are the major changes included in this PR:
- Added dummy UI button to trigger Android file picker and select attachment
- Implements `startAttachmentUpload`, upload request to S3 bucket and `completeAttachmentUpload` APIs
- Implemented unit tests for ChatService and new `AttachmentsManager` class.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
