### PR TITLE
Added unit tests and modified response handling

### DIFF
--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/MainActivity.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/MainActivity.kt
@@ -17,8 +17,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -228,6 +230,7 @@ fun ChatScreen(activity: Activity, viewModel: ChatViewModel = hiltViewModel()) {
 
         Column {
             ParticipantTokenSection(activity, viewModel)
+            Spacer(modifier = Modifier.height(16.dp))
             ConfigPicker(viewModel) // Include the configuration picker here
         }
 //        ParticipantTokenSection(activity, viewModel)
@@ -435,16 +438,13 @@ fun ChatMessage(
 fun ParticipantTokenSection(activity: Activity, viewModel: ChatViewModel) {
     val participantToken by viewModel.liveParticipantToken.observeAsState()
 
-    Column {
+    Column(modifier = Modifier.padding(16.dp).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = "Participant Token: ${if (participantToken != null) "Available" else "Not available"}",
             color = if (participantToken != null) Color.Blue else Color.Red
         )
         Button(onClick = viewModel::clearParticipantToken) {
             Text("Clear Participant Token")
-        }
-        Button(onClick = { viewModel.openFile(activity) }) {
-            Text(text = "Upload Attachment")
         }
     }
 }

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
@@ -68,6 +68,7 @@ class ChatViewModel @Inject constructor(
 
     fun setSelectedConfig(index: Int) {
         _selectedConfigIndex.value = index
+        clearParticipantToken()
         chatConfigProvider.updateConfig(index) // Update the current configuration
     }
 
@@ -85,9 +86,7 @@ class ChatViewModel @Inject constructor(
     }
 
     init {
-        viewModelScope.launch {
-            configureChatSession()
-        }
+
     }
 
     private suspend fun configureChatSession() {
@@ -135,6 +134,9 @@ class ChatViewModel @Inject constructor(
 
     fun initiateChat() {
         viewModelScope.launch {
+
+            configureChatSession()
+
             _isLoading.value = true
             messages = mutableStateListOf() // Clear existing messages
             if (participantToken != null) {
@@ -197,6 +199,7 @@ class ChatViewModel @Inject constructor(
                 // Handle successful connection
                 Log.d("ChatViewModel", "Connection successful $result")
             } else if (result.isFailure) {
+                Log.e("ChatViewModel", "Connection failed: ${result.exceptionOrNull()}")
                 _errorMessage.value = result.exceptionOrNull()?.message
             }
         }

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/ConfigPicker.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/ConfigPicker.kt
@@ -1,27 +1,50 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.amazon.connect.chat.androidchatexample.views
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.amazon.connect.chat.androidchatexample.Config
 import com.amazon.connect.chat.androidchatexample.viewmodel.ChatViewModel
 
 @Composable
 fun ConfigPicker(viewModel: ChatViewModel) {
-    val configOptions = listOf("Rajat acc","Pentest account 1", "Pentest account 2")
+    val configOptions = listOf(
+        "Micheal acc",
+        "Rajat acc",
+        "mobile-bug-bash-1",
+        "mobile-bug-bash-2",
+        "mobile-bug-bash-3",
+        "mobile-bug-bash-4",
+        "mobile-bug-bash-5",
+        "mobile-bug-bash-6",
+        "mobile-bug-bash-7",
+        "mobile-bug-bash-8"
+    )
     val selectedConfigIndex by viewModel.selectedConfigIndex.observeAsState(0)
+    var expanded by remember { mutableStateOf(false) }
+    var selectedOptionText by remember { mutableStateOf(configOptions[selectedConfigIndex]) }
 
     Column(
         modifier = Modifier
@@ -31,25 +54,71 @@ fun ConfigPicker(viewModel: ChatViewModel) {
     ) {
         Text("Select Configuration", style = MaterialTheme.typography.bodyLarge)
 
-        // Display radio buttons for selecting configuration
-        configOptions.forEachIndexed { index, option ->
-            Column(
+        // Exposed dropdown menu for selecting configuration
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            TextField(
+                value = selectedOptionText,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Configuration") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .padding(vertical = 8.dp)
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+            )
+
+            // The actual dropdown menu items
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }  // Dismiss when clicking outside
             ) {
-                RadioButton(
-                    selected = (selectedConfigIndex == index),
-                    onClick = {
-                        viewModel.setSelectedConfig(index)
-                    }
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(option)
-                Spacer(modifier = Modifier.width(8.dp))
+                configOptions.forEachIndexed { index, option ->
+                    DropdownMenuItem(
+                        text = { Text(option) },
+                        onClick = {
+                            selectedOptionText = option
+                            viewModel.setSelectedConfig(index)
+                            expanded = false  // Close the dropdown after selection
+                        }
+                    )
+                }
             }
-            Text("${Config.configurations[index]}")
+        }
+
+        val selectedConfig = Config.configurations[selectedConfigIndex]
+        Column(
+            modifier = Modifier.padding(top = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)) {
+
+            DetailText(label = "Connect Instance ID", value = selectedConfig.connectInstanceId)
+            DetailText(label = "Contact Flow ID", value = selectedConfig.contactFlowId)
+            DetailText(label = "Start Chat Endpoint", value = selectedConfig.startChatEndpoint)
+            DetailText(label = "Region", value = selectedConfig.region.name)
+            DetailText(label = "Agent Name", value = selectedConfig.agentName)
+            DetailText(label = "Customer Name", value = selectedConfig.customerName)
         }
     }
 }
+
+@Composable
+fun DetailText(label: String, value: String) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "$label:",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = Color.Gray,
+            modifier = Modifier.padding(bottom = 2.dp)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -33,13 +33,13 @@ interface ChatSession {
      * @param chatDetails The details of the chat.
      * @return A Result indicating whether the connection was successful.
      */
-    suspend fun connect(chatDetails: ChatDetails): Result<Unit>
+    suspend fun connect(chatDetails: ChatDetails): Result<Boolean>
 
     /**
      * Disconnects the current chat session.
      * @return A Result indicating whether the disconnection was successful.
      */
-    suspend fun disconnect(): Result<Unit>
+    suspend fun disconnect(): Result<Boolean>
 
     /**
      * Sends a message.
@@ -47,7 +47,7 @@ interface ChatSession {
      * @param contentType The content type of the message.
      * @return A Result indicating whether the message sending was successful.
      */
-    suspend fun sendMessage(contentType: ContentType, message: String): Result<Unit>
+    suspend fun sendMessage(contentType: ContentType, message: String): Result<Boolean>
 
     /**
      * Sends an event.
@@ -55,7 +55,7 @@ interface ChatSession {
      * @param contentType The content type of the event.
      * @return A Result indicating whether the event sending was successful.
      */
-    suspend fun sendEvent(contentType: ContentType, event: String): Result<Unit>
+    suspend fun sendEvent(contentType: ContentType, event: String): Result<Boolean>
 
     /**
      * Checks if a chat session is currently active.
@@ -67,7 +67,7 @@ interface ChatSession {
      * Sends an attachment.
      * @return A Result indicating whether sending the attachment was successful.
      */
-    suspend fun sendAttachment(fileUri: Uri): Result<Unit>
+    suspend fun sendAttachment(fileUri: Uri): Result<Boolean>
 
     /**
      * Downloads an attachment.
@@ -173,51 +173,31 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
         chatService.configure(config)
     }
 
-    override suspend fun connect(chatDetails: ChatDetails): Result<Unit> {
+    override suspend fun connect(chatDetails: ChatDetails): Result<Boolean> {
         // Establish subscriptions whenever a new chat session is initiated
         setupEventSubscriptions()
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.createChatSession(chatDetails)
-                Result.success(Unit)
-            }.getOrElse {
-                Result.failure(it)
-            }
+            chatService.createChatSession(chatDetails)
         }
     }
 
-    override suspend fun disconnect(): Result<Unit> {
+    override suspend fun disconnect(): Result<Boolean> {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.disconnectChatSession()
-                Result.success(Unit)
-            }.getOrElse {
-                Result.failure(it)
-            }
+            chatService.disconnectChatSession()
         }.also {
             cleanup()
         }
     }
 
-    override suspend fun sendMessage(contentType: ContentType, message: String): Result<Unit> {
+    override suspend fun sendMessage(contentType: ContentType, message: String): Result<Boolean> {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.sendMessage(contentType, message)
-                Result.success(Unit)
-            }.getOrElse {
-                Result.failure(it)
-            }
+            chatService.sendMessage(contentType, message)
         }
     }
 
-    override suspend fun sendEvent(contentType: ContentType, content: String): Result<Unit> {
+    override suspend fun sendEvent(contentType: ContentType, content: String): Result<Boolean> {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.sendEvent(contentType, content)
-                Result.success(Unit)
-            }.getOrElse {
-                Result.failure(it)
-            }
+            chatService.sendEvent(contentType, content)
         }
     }
 
@@ -233,17 +213,13 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
         transcriptListCollectionJob = null
         chatSessionStateCollectionJob = null
     }
-    
-    override suspend fun sendAttachment(fileUri: Uri): Result<Unit> {
+
+    override suspend fun sendAttachment(fileUri: Uri): Result<Boolean> {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.sendAttachment(fileUri)
-                Result.success(Unit)
-            }.getOrElse {
-                Result.failure(it)
-            }
+            chatService.sendAttachment(fileUri)
         }
     }
+
 
     override suspend fun downloadAttachment(attachmentId: String, filename: String): Result<URL> {
         return withContext(Dispatchers.IO) {

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
@@ -1,9 +1,19 @@
 package com.amazon.connect.chat.sdk
 
+import android.net.Uri
 import com.amazon.connect.chat.sdk.model.ChatDetails
+import com.amazon.connect.chat.sdk.model.ContentType
 import com.amazon.connect.chat.sdk.model.GlobalConfig
+import com.amazon.connect.chat.sdk.model.Message
+import com.amazon.connect.chat.sdk.model.MessageDirection
+import com.amazon.connect.chat.sdk.model.MessageMetadata
+import com.amazon.connect.chat.sdk.model.MessageReceiptType
+import com.amazon.connect.chat.sdk.model.MessageStatus
+import com.amazon.connect.chat.sdk.model.TranscriptResponse
 import com.amazon.connect.chat.sdk.repository.ChatService
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.connectparticipant.model.ScanDirection
+import com.amazonaws.services.connectparticipant.model.SortKey
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -11,10 +21,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.*
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+import java.net.URL
 
 
 @ExperimentalCoroutinesApi
@@ -53,7 +64,7 @@ class ChatSessionImplTest {
     @Test
     fun test_connect_failure() = runTest {
         val chatDetails = ChatDetails(participantToken = "invalid token")
-        `when`(chatService.createChatSession(chatDetails)).thenThrow(RuntimeException("Network error"))
+        `when`(chatService.createChatSession(chatDetails)).thenReturn(Result.failure(Exception("Network error")))
 
         val result = chatSession.connect(chatDetails)
 
@@ -73,12 +84,160 @@ class ChatSessionImplTest {
 
     @Test
     fun test_disconnect_failure() = runTest {
-        `when`(chatService.disconnectChatSession()).thenThrow(RuntimeException("Network error"))
+        `when`(chatService.disconnectChatSession()).thenReturn(Result.failure(Exception("Network error")))
 
         val result = chatSession.disconnect()
 
         assertTrue(result.isFailure)
         verify(chatService).disconnectChatSession()
+    }
+
+    @Test
+    fun test_sendMessage_success() = runTest {
+        val message = "Hello"
+        val contentType = ContentType.PLAIN_TEXT
+        `when`(chatService.sendMessage(contentType, message)).thenReturn(Result.success(true))
+
+        val result = chatSession.sendMessage(contentType, message)
+
+        assertTrue(result.isSuccess)
+        verify(chatService).sendMessage(contentType, message)
+    }
+
+    @Test
+    fun test_sendMessage_failure() = runTest {
+        val message = "Hello"
+        val contentType = ContentType.PLAIN_TEXT
+        `when`(chatService.sendMessage(contentType, message)).thenReturn(Result.failure(Exception("Send error")))
+
+        val result = chatSession.sendMessage(contentType, message)
+
+        assertTrue(result.isFailure)
+        verify(chatService).sendMessage(contentType, message)
+    }
+
+    @Test
+    fun test_sendEvent_success() = runTest {
+        val event = "Typing Event data"
+        val contentType = ContentType.TYPING
+        `when`(chatService.sendEvent(contentType, event)).thenReturn(Result.success(true))
+
+        val result = chatSession.sendEvent(contentType, event)
+
+        assertTrue(result.isSuccess)
+        verify(chatService).sendEvent(contentType, event)
+    }
+
+    @Test
+    fun test_sendEvent_failure() = runTest {
+        val event = "Typing Event data"
+        val contentType = ContentType.TYPING
+        `when`(chatService.sendEvent(contentType, event)).thenReturn(Result.failure(Exception("Event error")))
+
+        val result = chatSession.sendEvent(contentType, event)
+
+        assertTrue(result.isFailure)
+        verify(chatService).sendEvent(contentType, event)
+    }
+
+    @Test
+    fun test_sendAttachment_success() = runTest {
+        val fileUri = Uri.parse("file://path/to/file")
+        `when`(chatService.sendAttachment(fileUri)).thenReturn(Result.success(true))
+
+        val result = chatSession.sendAttachment(fileUri)
+
+        assertTrue(result.isSuccess)
+        verify(chatService).sendAttachment(fileUri)
+    }
+
+    @Test
+    fun test_sendAttachment_failure() = runTest {
+        val fileUri = Uri.parse("file://path/to/file")
+        `when`(chatService.sendAttachment(fileUri)).thenReturn(Result.failure(Exception("Attachment error")))
+
+        val result = chatSession.sendAttachment(fileUri)
+
+        assertTrue(result.isFailure)
+        verify(chatService).sendAttachment(fileUri)
+    }
+
+    @Test
+    fun test_downloadAttachment_success() = runTest {
+        val attachmentId = "attachmentId"
+        val filename = "filename"
+        val expectedUrl = URL("https://example.com/file")
+        `when`(chatService.downloadAttachment(attachmentId, filename)).thenReturn(Result.success(expectedUrl))
+
+        val result = chatSession.downloadAttachment(attachmentId, filename)
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull() == expectedUrl)
+        verify(chatService).downloadAttachment(attachmentId, filename)
+    }
+
+    @Test
+    fun test_downloadAttachment_failure() = runTest {
+        val attachmentId = "attachmentId"
+        val filename = "filename"
+        `when`(chatService.downloadAttachment(attachmentId, filename)).thenReturn(Result.failure(Exception("Download error")))
+
+        val result = chatSession.downloadAttachment(attachmentId, filename)
+
+        assertTrue(result.isFailure)
+        verify(chatService).downloadAttachment(attachmentId, filename)
+    }
+
+    @Test
+    fun test_getTranscript_success() = runTest {
+        val scanDirection: ScanDirection? = null
+        val sortKey: SortKey? = null
+        val maxResults: Int? = 10
+        val nextToken: String? = null
+        val startPosition: String? = null
+        val transcriptResponse = TranscriptResponse("","",listOf())
+        `when`(chatService.getTranscript(scanDirection, sortKey, maxResults, nextToken, null)).thenReturn(Result.success(transcriptResponse))
+
+        val result = chatSession.getTranscript(scanDirection, sortKey, maxResults, nextToken, startPosition)
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull() == transcriptResponse)
+        verify(chatService).getTranscript(scanDirection, sortKey, maxResults, nextToken, null)
+    }
+
+    @Test
+    fun test_getTranscript_failure() = runTest {
+        val scanDirection: ScanDirection? = null
+        val sortKey: SortKey? = null
+        val maxResults: Int? = 10
+        val nextToken: String? = null
+        val startPosition: String? = null
+        `when`(chatService.getTranscript(scanDirection, sortKey, maxResults, nextToken, null)).thenReturn(Result.failure(Exception("Transcript error")))
+
+        val result = chatSession.getTranscript(scanDirection, sortKey, maxResults, nextToken, startPosition)
+
+        assertTrue(result.isFailure)
+        verify(chatService).getTranscript(scanDirection, sortKey, maxResults, nextToken, null)
+    }
+
+    @Test
+    fun test_sendMessageReceipt_callsSendReceipt() = runTest {
+            val message = Message(
+            id = "messageId",
+            timeStamp = "timestamp",
+            text = "dummy text",
+            participant = "AGENT",
+            contentType = ContentType.PLAIN_TEXT.type,
+            messageDirection = MessageDirection.INCOMING,
+            metadata = MessageMetadata(id = "messageId", timeStamp = "timestamp", contentType="PLAIN_TEXT", status  = MessageStatus.Delivered,)
+        )
+        val receiptType = MessageReceiptType.MESSAGE_READ
+
+        `when`(chatService.sendMessageReceipt(receiptType, message.id)).thenReturn(Result.success(Unit))
+
+        chatSession.sendMessageReceipt(message, receiptType)
+
+        verify(chatService).sendMessageReceipt(receiptType, message.id)
     }
 
 }


### PR DESCRIPTION


**Issue Number:**

### Description:
*What are the changes? Why are we making them?*
- Added unit test for chatsession and chatservice file
- Modified UI for bug bash, will remove before launch.
- Modified response/error handling from chatsesison


---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

