### PR TITLE
Implementing getAttachmentDownloadUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,23 @@ suspend fun downloadAttachment(attachmentId: String, filename: String): Result<U
   * The name of the file to save the attachment as.
   * Type: `String`
 * Return result type: `URL`
+  * The return URL points to the location of the downloaded attachment in the local temporary storage.
+  
+--------------------
 
+#### `ChatSession.getAttachmentDownloadUrl`
+Returns the download URL link for the given attachment ID.
+
+```
+suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL>
+```
+
+* `attachmentId`
+  * The ID of the attachment.
+  * Type: `String`
+* Return result type: `URL`
+  * This return URL points to the S3 download URL of the attachment.
+ 
 --------------------
 
 ### ChatSession Events

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -75,6 +75,13 @@ interface ChatSession {
     suspend fun downloadAttachment(attachmentId: String, filename: String): Result<URL>
 
     /**
+     * Returns the S3 download URL for an attachment.
+     * @param attachmentId The ID of the attachment.
+     * @return A Result containing the download URL for the attachment.
+     */
+    suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL>
+
+    /**
      * Gets the transcript.
      * @param scanDirection The direction of the scan.
      * @param sortKey The sort key.
@@ -216,6 +223,14 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
         return withContext(Dispatchers.IO) {
             runCatching {
                 chatService.downloadAttachment(attachmentId, filename).getOrThrow()
+            }
+        }
+    }
+
+    override suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                chatService.getAttachmentDownloadUrl(attachmentId).getOrThrow()
             }
         }
     }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
@@ -110,9 +110,9 @@ class AttachmentsManager @Inject constructor(
     }
 
     suspend fun downloadAttachment(
+        connectionToken: String,
         attachmentId: String,
         fileName: String,
-        connectionToken: String
     ): Result<URL> {
         return getAttachmentDownloadUrl(connectionToken, attachmentId).mapCatching { url ->
             downloadFile(url, fileName).getOrThrow()
@@ -121,7 +121,7 @@ class AttachmentsManager @Inject constructor(
         }
     }
 
-    private suspend fun getAttachmentDownloadUrl(connectionToken: String, attachmentId: String): Result<URL> {
+    suspend fun getAttachmentDownloadUrl(connectionToken: String, attachmentId: String): Result<URL> {
         return runCatching {
             val response = awsClient.getAttachment(connectionToken, attachmentId)
             URL(response.getOrNull()?.url ?: throw IOException("Invalid URL"))

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
@@ -53,9 +53,7 @@ class AttachmentsManager @Inject constructor(
                 file
             ) { response ->
                 CoroutineScope(Dispatchers.IO).launch {
-                    print("DEBUG!!")
                     if (response != null && response.isSuccessful) {
-                        print("DEBUG2!!")
                         completeAttachmentUpload(connectionToken, attachmentId)
                     } else {
                         val exception = response?.message()

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AttachmentsManager.kt
@@ -53,7 +53,9 @@ class AttachmentsManager @Inject constructor(
                 file
             ) { response ->
                 CoroutineScope(Dispatchers.IO).launch {
+                    print("DEBUG!!")
                     if (response != null && response.isSuccessful) {
+                        print("DEBUG2!!")
                         completeAttachmentUpload(connectionToken, attachmentId)
                     } else {
                         val exception = response?.message()
@@ -68,6 +70,7 @@ class AttachmentsManager @Inject constructor(
     }
 
     suspend fun completeAttachmentUpload(connectionToken: String, attachmentId: String) {
+        print("HIT!!")
         val request = CompleteAttachmentUploadRequest().apply {
             this.connectionToken = connectionToken
             this.setAttachmentIds(listOf(attachmentId))
@@ -130,7 +133,7 @@ class AttachmentsManager @Inject constructor(
         }
     }
 
-    private suspend fun downloadFile(url: URL, fileName: String): Result<URL> = withContext(Dispatchers.IO) {
+    suspend fun downloadFile(url: URL, fileName: String): Result<URL> = withContext(Dispatchers.IO) {
         runCatching {
             val connection = url.openConnection() as HttpURLConnection
             connection.requestMethod = "GET"

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -600,7 +600,7 @@ class ChatServiceImpl @Inject constructor(
                 ?: throw Exception("No connection details available")
             attachmentsManager.downloadAttachment(connectionDetails.connectionToken, attachmentId, fileName).getOrThrow()
         }.onFailure { exception ->
-            SDKLogger.logger.logError { "Failed to download attachment: ${exception.message}" }
+            SDKLogger.logger.logError { "Failed to download attachment for attachmentId $attachmentId. Error: ${exception.message}" }
         }
     }
 
@@ -610,7 +610,7 @@ class ChatServiceImpl @Inject constructor(
                 ?: throw Exception("No connection details available")
             attachmentsManager.getAttachmentDownloadUrl(attachmentId, connectionDetails.connectionToken).getOrThrow()
         }.onFailure { exception ->
-            SDKLogger.logger.logError { "Failed to retrieve attachment download URL: ${exception.message}" }
+            SDKLogger.logger.logError { "Failed to retrieve attachment download URL for attachment $attachmentId. Error: ${exception.message}" }
         }
     }
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -98,6 +98,14 @@ interface ChatService {
      */
     suspend fun downloadAttachment(attachmentId: String, fileName: String): Result<URL>
 
+
+    /**
+     * Returns the S3 download URL for an attachment.
+     * @param attachmentId The ID of the attachment.
+     * @return A Result containing the download URL for the attachment.
+     */
+    suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL>
+
     /**
      * Gets the transcript.
      * @param scanDirection The direction of the scan.
@@ -590,9 +598,19 @@ class ChatServiceImpl @Inject constructor(
         return runCatching {
             val connectionDetails = connectionDetailsProvider.getConnectionDetails()
                 ?: throw Exception("No connection details available")
-            attachmentsManager.downloadAttachment(attachmentId, fileName, connectionDetails.connectionToken).getOrThrow()
+            attachmentsManager.downloadAttachment(connectionDetails.connectionToken, attachmentId, fileName).getOrThrow()
         }.onFailure { exception ->
             SDKLogger.logger.logError { "Failed to download attachment: ${exception.message}" }
+        }
+    }
+
+    override suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL> {
+        return runCatching {
+            val connectionDetails = connectionDetailsProvider.getConnectionDetails()
+                ?: throw Exception("No connection details available")
+            attachmentsManager.getAttachmentDownloadUrl(attachmentId, connectionDetails.connectionToken).getOrThrow()
+        }.onFailure { exception ->
+            SDKLogger.logger.logError { "Failed to retrieve attachment download URL: ${exception.message}" }
         }
     }
 

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -326,13 +326,13 @@ class ChatServiceImplTest {
         val mockConnectionDetails = createMockConnectionDetails("valid_token")
 
         `when`(connectionDetailsProvider.getConnectionDetails()).thenReturn(mockConnectionDetails)
-        `when`(attachmentsManager.downloadAttachment(attachmentId, fileName, mockConnectionDetails.connectionToken)).thenReturn(Result.success(mockUrl))
+        `when`(attachmentsManager.downloadAttachment(mockConnectionDetails.connectionToken, attachmentId, fileName)).thenReturn(Result.success(mockUrl))
 
         val result = chatService.downloadAttachment(attachmentId, fileName)
 
         assertTrue(result.isSuccess)
         assertEquals(mockUrl, result.getOrNull())
-        verify(attachmentsManager).downloadAttachment(attachmentId, fileName, mockConnectionDetails.connectionToken)
+        verify(attachmentsManager).downloadAttachment(mockConnectionDetails.connectionToken, attachmentId, fileName)
     }
 
     @Test
@@ -342,12 +342,12 @@ class ChatServiceImplTest {
         val mockConnectionDetails = createMockConnectionDetails("valid_token")
 
         `when`(connectionDetailsProvider.getConnectionDetails()).thenReturn(mockConnectionDetails)
-        `when`(attachmentsManager.downloadAttachment(attachmentId, fileName, mockConnectionDetails.connectionToken)).thenThrow(RuntimeException("Download error"))
+        `when`(attachmentsManager.downloadAttachment(mockConnectionDetails.connectionToken, attachmentId, fileName)).thenThrow(RuntimeException("Download error"))
 
         val result = chatService.downloadAttachment(attachmentId, fileName)
 
         assertTrue(result.isFailure)
-        verify(attachmentsManager).downloadAttachment(attachmentId, fileName, mockConnectionDetails.connectionToken)
+        verify(attachmentsManager).downloadAttachment(mockConnectionDetails.connectionToken, attachmentId, fileName)
     }
 
     @Test


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

Implementing `getAttachmentDownloadUrl` + unit tests.

`getAttachmentDownloadUrl` will return the S3 download URL for an attachment in the case the user wants to handle the download logic themselves.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

