### PR TITLE
Fixing end chat behavior

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -20,6 +20,7 @@ import com.amazonaws.services.connectparticipant.model.StartPosition
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.net.URL
@@ -148,7 +149,11 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
                     ChatEvent.ConnectionReEstablished -> onConnectionReEstablished?.invoke()
                     ChatEvent.ChatEnded -> {
                         onChatEnded?.invoke()
-                        cleanup()
+                        coroutineScope.launch {
+                            // Provide some time for transcript to update and surface end event to user.
+                            delay(500)
+                            cleanup()
+                        }
                     }
                     ChatEvent.ConnectionBroken -> onConnectionBroken?.invoke()
                     ChatEvent.DeepHeartBeatFailure -> onDeepHeartBeatFailure?.invoke()

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -236,11 +236,6 @@ class ChatServiceImpl @Inject constructor(
                     }
                 }
                 _eventPublisher.emit(event)
-
-                // Cleanup when chat ends, making sure that it cleanups after event has been emitted
-                if (event == ChatEvent.ChatEnded) {
-                    clearSubscriptionsAndPublishers()
-                }
             }
         }
 
@@ -374,6 +369,9 @@ class ChatServiceImpl @Inject constructor(
             }
 
             _transcriptListPublisher.emit(internalTranscript)
+            if (ContentType.fromType(item.contentType) == ContentType.ENDED) {
+                clearSubscriptionsAndPublishers()
+            }
         }
     }
 


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR fixes end chat behavior by changing the ordering of when subscribers are reset and when events are being sent.  Currently, we are cleaning up subscribers before the event is properly sent over to the front-end.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

N/A

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

