### PR TITLE
Fixes the bug where chat was getting stuck while retrieving previous session's transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ suspend fun sendMessageReceipt(transcriptItem: TranscriptItem, receiptType: Mess
 --------------------
 
 #### `ChatSession.getTranscript`
+
 Retrieves the chat transcript.
 
 ```
@@ -278,6 +279,20 @@ suspend fun getTranscript(
   * The start position for the transcript.
   * Type: `StartPosition?`. See [StartPosition](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_StartPosition.html)
 * Return result type: [TranscriptResponse](#transcriptresponse)
+
+Upon establishing a connection, the SDK automatically calls `getTranscript` to retrieve messages
+sent while the app was in the background, offline, or in similar disconnected states. Users can also
+call `getTranscript` as they need, for example - pull to fetch previous message etc.
+
+Here's how `getTranscript` works in SDK:
+
+* **Automatic Transcript Management:** The SDK automatically manages the received transcript.
+  New messages are delivered through the `onTranscriptUpdated` and `onMessageReceived` callbacks.
+* **Pagination:** The response includes a `nextToken` that you can use to fetch additional messages
+  if the transcript is large.
+
+For more information on how getTranscript API works, please
+visit [GetTranscript](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_GetTranscript.html)
 
 --------------------
 

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/MainActivity.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/MainActivity.kt
@@ -307,14 +307,14 @@ fun ChatView(viewModel: ChatViewModel, activity: Activity) {
 
     val onRefresh: () -> Unit = {
         isRefreshing = true
-        viewModel.fetchTranscript { success ->
+        viewModel.fetchTranscript(onCompletion = { success ->
             isRefreshing = false
             if (success) {
                 Log.d("ChatView", "Transcript fetched successfully")
             } else {
                 Log.e("ChatView", "Failed to fetch transcript")
             }
-        }
+        })
     }
 
     // Scroll to the last message when messages change
@@ -369,7 +369,6 @@ fun ChatView(viewModel: ChatViewModel, activity: Activity) {
                     LaunchedEffect(key1 = message, key2 = index) {
                         if (message.contentType == ContentType.ENDED.type) {
                             isChatEnded = true
-                            viewModel.clearParticipantToken()
                         } else {
                             isChatEnded = false
                         }
@@ -445,8 +444,18 @@ fun ChatMessage(
 @Composable
 fun ParticipantTokenSection(activity: Activity, viewModel: ChatViewModel) {
     val participantToken by viewModel.liveParticipantToken.observeAsState()
+    val contactId by viewModel.liveContactId.observeAsState()
 
     Column(modifier = Modifier.padding(16.dp).fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = "Contact Id: ${if (contactId != null) "Available" else "Not available"}",
+            color = if (contactId != null) Color.Blue else Color.Red
+        )
+        Button(onClick = viewModel::clearContactId) {
+            Text("Clear Contact Id")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+
         Text(
             text = "Participant Token: ${if (participantToken != null) "Available" else "Not available"}",
             color = if (participantToken != null) Color.Blue else Color.Red

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/models/StartChatRequest.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/models/StartChatRequest.kt
@@ -6,6 +6,7 @@ data class StartChatRequest(
     @SerializedName("InstanceId") val connectInstanceId: String,
     @SerializedName("ContactFlowId") val contactFlowId: String,
     @SerializedName("ParticipantDetails") val participantDetails: ParticipantDetails,
+    @SerializedName("PersistentChat") val persistentChat: PersistentChat? = null,
     @SerializedName("SupportedMessagingContentTypes") val supportedMessagingContentTypes: List<String> = listOf("text/plain", "text/markdown")
 )
 
@@ -13,3 +14,7 @@ data class ParticipantDetails(
     @SerializedName("DisplayName") val displayName: String
 )
 
+data class PersistentChat(
+    @SerializedName("SourceContactId") val sourceContactId: String,
+    @SerializedName("RehydrationType") val rehydrationType: String
+)

--- a/chat-sdk/build.gradle.kts
+++ b/chat-sdk/build.gradle.kts
@@ -63,46 +63,46 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.androidxLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityCompose)
-    implementation(platform(libs.composeBom))
-    implementation(libs.composeUi)
-    implementation(libs.composeUiGraphics)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.material3)
-    implementation(libs.runtimeLivedata)
+    api(libs.androidxCoreKtx)
+    api(libs.androidxLifecycleRuntimeKtx)
+    api(libs.androidxActivityCompose)
+    api(platform(libs.composeBom))
+    api(libs.composeUi)
+    api(libs.composeUiGraphics)
+    api(libs.composeUiToolingPreview)
+    api(libs.material3)
+    api(libs.runtimeLivedata)
 
     // Lifecycle livedata
-    implementation(libs.lifecycleLivedataKtx)
-    implementation(libs.lifecycleViewmodelKtx)
-    implementation(libs.coroutinesAndroid)
+    api(libs.lifecycleLivedataKtx)
+    api(libs.lifecycleViewmodelKtx)
+    api(libs.coroutinesAndroid)
 
     // Retrofit
-    implementation(libs.retrofit)
-    implementation(libs.converterGson)
-    implementation(libs.okhttp)
-    implementation(libs.loggingInterceptor)
-    implementation(libs.otto)
-    implementation(libs.adapterRxjava2)
+    api(libs.retrofit)
+    api(libs.converterGson)
+    api(libs.okhttp)
+    api(libs.loggingInterceptor)
+    api(libs.otto)
+    api(libs.adapterRxjava2)
 
     //Hilt
-    implementation(libs.hiltAndroid)
-    implementation(libs.hiltNavigationCompose)
-    implementation(libs.lifecycleProcess)
+    api(libs.hiltAndroid)
+    api(libs.hiltNavigationCompose)
+    api(libs.lifecycleProcess)
     kapt(libs.hiltCompiler)
-    implementation(libs.navigationCompose)
+    api(libs.navigationCompose)
     kapt(libs.hiltAndroidCompiler)
 
     // AWS
-    implementation(libs.awsSdkCore)
-    implementation(libs.awsSdkConnectParticipant)
+    api(libs.awsSdkCore)
+    api(libs.awsSdkConnectParticipant)
 
     // Serialization
-    implementation(libs.serializationJson)
+    api(libs.serializationJson)
 
     // Image loading
-    implementation(libs.coilCompose)
+    api(libs.coilCompose)
 
     // Testing
     // Mockito for mocking
@@ -133,25 +133,23 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
 // Can be used in example app like below
 // Keeping group Id different for local testing purpose
 // implementation("com.amazon.connect.chat.sdk:connect-chat-sdk:1.0.0")
-publishing {
-    publications {
-        // Create a MavenPublication for the release build type
-        create<MavenPublication>("release") {
-            afterEvaluate {
-                artifact(tasks.getByName("bundleReleaseAar"))
-            }
-            groupId = "com.amazon.connect.chat.sdk"
-            artifactId = "connect-chat-sdk"
-            version = "1.0.0"
-
-
-        }
-    }
-    // Define the repository where the artifact will be published
-    repositories {
-        mavenLocal()
-    }
-}
+//publishing {
+//    publications {
+//        // Create a MavenPublication for the release build type
+//        create<MavenPublication>("release") {
+//            afterEvaluate {
+//                artifact(tasks.getByName("bundleReleaseAar"))
+//            }
+//            groupId = "com.amazon.connect.chat.sdk"
+//            artifactId = "connect-chat-sdk"
+//            version = "1.0.2"
+//        }
+//    }
+//    // Define the repository where the artifact will be published
+//    repositories {
+//        mavenLocal()
+//    }
+//}
 
 
 // Test summary gradle file

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -369,9 +369,6 @@ class ChatServiceImpl @Inject constructor(
             }
 
             _transcriptListPublisher.emit(internalTranscript)
-            if (ContentType.fromType(item.contentType) == ContentType.ENDED) {
-                clearSubscriptionsAndPublishers()
-            }
         }
     }
 
@@ -424,6 +421,8 @@ class ChatServiceImpl @Inject constructor(
             awsClient.disconnectParticipantConnection(connectionDetails.connectionToken)
                 .getOrThrow()
             SDKLogger.logger.logDebug { "Participant Disconnected" }
+            webSocketManager.disconnect("Customer ended the chat")
+            _eventPublisher.emit(ChatEvent.ChatEnded)
             connectionDetailsProvider.setChatSessionState(false)
             true
         }.onFailure { exception ->

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.1
+sdkVersion=1.0.3
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

The issue arises when users attempt to load the transcript from a previous session using persistent chat. While we were processing the response in Android, we had added a “closing” WebSocket and sent a “chat has ended” callback to the customer after parsing an “chat ended” event that we received in the transcript.

This fix prevents the action from being taken at the parsing level and instead sends the “chat has ended” callback to the customer once they disconnect and close the WebSocket simultaneously. 

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/**NO**]

*Does this change introduce any new dependency?* [YES/**NO**]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

