### PR TITLE
Modified logic to handle previous chat ended events

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -416,6 +416,15 @@ class ChatServiceImpl @Inject constructor(
 
     override suspend fun disconnectChatSession(): Result<Boolean> {
         return runCatching {
+            // Check if the chat session is active
+            if (!connectionDetailsProvider.isChatSessionActive()) {
+                webSocketManager.disconnect("Session inactive")
+                clearSubscriptionsAndPublishers()
+                SDKLogger.logger.logDebug { "Chat session is inactive. Disconnecting websocket and clearing resources." }
+                return Result.success(true) // Successfully handled the inactive session case
+            }
+
+            // Proceed with the disconnection logic
             val connectionDetails = connectionDetailsProvider.getConnectionDetails()
                 ?: throw Exception("No connection details available")
             awsClient.disconnectParticipantConnection(connectionDetails.connectionToken)

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
@@ -84,7 +84,8 @@ object TranscriptItemUtils {
                 "Content" to (item.content ?: ""),
                 "Type" to item.type,
                 "DisplayName" to (item.displayName ?: ""),
-                "Attachments" to attachmentsArray
+                "Attachments" to attachmentsArray,
+                "isFromPastSession" to true // Mark all these items as coming from a past session
             )
 
             // Serialize the dictionary to JSON string

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.4
+sdkVersion=1.0.5
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

- Removed time based event comparison, Now we will attach `isFromPastSession` to getTranscript result items to track of past items and take action based on this flag. This reduces our dependency on tracking time and managing it!
- `isFromPastSession` will be marked as `true` for all getTranscript items and while fetching the object, default is set to `false`


---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

