### PR TITLE
Improved fallback mechanism when user is not using hilt/dagger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Save Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-build
           path: app/build/outputs/apk/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,61 +76,19 @@ jobs:
       - name: Run Unit Tests and Capture Results
         id: run_tests
         run: |
+          # Run tests and capture exit code
           ./gradlew test | tee test-results.txt
-          TEST_RESULTS=$(grep -A 7 "Test Summary" test-results.txt | tail -n +2 | sed 's/\x1B\[[0-9;]*[JKmsu]//g' | tr -d '[:space:]')
-          echo "$TEST_RESULTS" > test-summary.txt
-
-      # - name: Format Test Results for Two-Row Markdown Table with Emojis
-      #   run: |
-      #     echo "### Test Results" > formatted-summary.txt
-      #     echo "" >> formatted-summary.txt
-      #     echo "| Total Tests | Passed | Failed | Skipped | Result |" >> formatted-summary.txt
-      #     echo "|-------------|--------|--------|---------|--------|" >> formatted-summary.txt
-  
-      #     echo "Raw Test Summary Content:"
-      #     cat test-summary.txt
-  
-      #     # Extracting values using awk
-      #     TOTAL=$(echo "$TEST_RESULTS" | awk -F'[: ]+' '/TotalTests/ {print $2}')
-      #     PASSED=$(echo "$TEST_RESULTS" | awk -F'[: ]+' '/Passed/ {print $2}')
-      #     FAILED=$(echo "$TEST_RESULTS" | awk -F'[: ]+' '/Failed/ {print $2}')
-      #     SKIPPED=$(echo "$TEST_RESULTS" | awk -F'[: ]+' '/Skipped/ {print $2}')
-      #     RESULT=$(echo "$TEST_RESULTS" | awk -F'[: ]+' '/Result/ {print $2}')
-  
-      #     # Detailed debugging
-      #     echo "Debug: Extracted Values:"
-      #     echo "  TOTAL: '$TOTAL'"
-      #     echo "  PASSED: '$PASSED'"
-      #     echo "  FAILED: '$FAILED'"
-      #     echo "  SKIPPED: '$SKIPPED'"
-      #     echo "  RESULT (Raw): '$RESULT'"
-  
-      #     if [[ "$RESULT" == "SUCCESS" ]]; then
-      #       EMOJI="✅"
-      #     elif [[ "$RESULT" == "FAILURE" ]]; then
-      #       EMOJI="❌"
-      #     else
-      #       EMOJI="⚠️"
-      #     fi
-  
-      #     echo "Debug: Final RESULT after processing: '$RESULT $EMOJI'"
-  
-      #     echo "| $TOTAL | $PASSED | $FAILED | $SKIPPED | $RESULT $EMOJI |" >> formatted-summary.txt
-  
-      #     # Show the final output for debugging
-      #     echo "Final formatted-summary.txt content:"
-      #     cat formatted-summary.txt
-        
-      # - name: Comment on PR
-      #   if: github.event_name == 'pull_request'
-      #   uses: actions/github-script@v6
-      #   with:
-      #     script: |
-      #       const fs = require('fs');
-      #       const testResults = fs.readFileSync('formatted-summary.txt', 'utf8');
-      #       github.rest.issues.createComment({
-      #         issue_number: context.issue.number,
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         body: testResults
-      #       });
+          TEST_EXIT_CODE=${PIPESTATUS[0]}  # Capture the exit code of ./gradlew test
+      
+          # Extract a clean test summary from Gradle output
+          echo "### 📌 Unit Test Summary" > test-summary.txt
+          grep -A 10 "Test Summary" test-results.txt | tail -n +2 | sed 's/\x1B\[[0-9;]*[JKmsu]//g' >> test-summary.txt
+      
+          # Print the test summary in GitHub Actions logs
+          cat test-summary.txt
+      
+          # Fail the workflow if tests fail
+          if [ $TEST_EXIT_CODE -ne 0 ]; then
+            echo "❌ Unit tests failed. See test-results.txt for details."
+            exit $TEST_EXIT_CODE  # Fail the workflow
+          fi

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload Semgrep results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: semgrep-results
           path: semgrep.sarif

--- a/chat-sdk/build.gradle.kts
+++ b/chat-sdk/build.gradle.kts
@@ -81,8 +81,8 @@ dependencies {
     implementation(libs.loggingInterceptor)
 
     //Hilt
-    implementation(libs.hiltAndroid)
-    implementation(libs.lifecycleProcess)
+    compileOnly(libs.hiltAndroid)
+    compileOnly(libs.lifecycleProcess)
     kapt(libs.hiltCompiler)
     kapt(libs.hiltAndroidCompiler)
 

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.5
+sdkVersion=1.0.6
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

- We got feedback that app was crashing if user did not have dagger/hilt dependencies in their app, now we have improved the fallback and it will try to initialize manually. 

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

