### PR TITLE
Removed transitive dependencies, exposed method to retry undelivered …

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,19 @@ suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL>
  
 --------------------
 
+#### `ChatSession.resendFailedMessage`
+Retry a text message or attachment that failed to be sent.
+
+```
+suspend fun resendFailedMessage(messageId: String): Result<Boolean>
+```
+
+* `messageId`
+  * messageId The Id of the message that failed to be sent.
+  * Type: `String`
+
+--------------------
+
 ### ChatSession Events
 
 #### `ChatSession.onConnectionEstablished`

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/utils/CommonUtils.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/utils/CommonUtils.kt
@@ -108,4 +108,8 @@ object CommonUtils {
             else -> ""  // Returning empty string for unknown or null status
         }
     }
+
+    fun retryButtonEnabled(status: String): Boolean {
+        return !arrayOf("Delivered", "Read", "Sending", "Sent").contains(status)
+    }
 }

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
@@ -175,6 +175,21 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    fun resendFailedMessage(messageId: String) {
+        viewModelScope.launch {
+            if (messageId.isNotEmpty()) {
+                val result = chatSession.resendFailedMessage(messageId)
+                result.onSuccess {
+                    // Handle success - update UI or state as needed
+                }.onFailure { exception ->
+                    // Handle failure - update UI or state, log error, etc.
+                    Log.e("ChatViewModel", "Error re-sending message: ${exception.message}")
+                }
+            }
+        }
+
+    }
+
     // Start a new chat session by sending a StartChatRequest to the repository
     private fun startChat(sourceContactId: String? = null) {
         viewModelScope.launch {

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/AttachmentMessageView.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/AttachmentMessageView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.amazon.connect.chat.androidchatexample.utils.CommonUtils
+import com.amazon.connect.chat.androidchatexample.utils.CommonUtils.retryButtonEnabled
 import com.amazon.connect.chat.androidchatexample.viewmodel.ChatViewModel
 import com.amazon.connect.chat.sdk.model.Message
 import com.amazon.connect.chat.sdk.model.MessageDirection
@@ -144,7 +146,9 @@ fun AttachmentMessageView(
                 }
             }
 
-            if (message.messageDirection == MessageDirection.OUTGOING && message.id == recentOutgoingMessageID) {
+            // display message status only when the message wasn't sent successfully, or it is the recent outgoing message
+            val retryEnabled = retryButtonEnabled(CommonUtils.customMessageStatus(message.metadata?.status))
+            if (message.messageDirection == MessageDirection.OUTGOING && (message.id == recentOutgoingMessageID || retryEnabled)) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth(),
@@ -157,6 +161,13 @@ fun AttachmentMessageView(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
+                }
+                if (retryEnabled) {
+                    TextButton(
+                        onClick = {
+                            chatViewModel.resendFailedMessage(message.id)
+                        }
+                    ) { Text("Retry") }
                 }
             }
         }

--- a/chat-sdk/build.gradle.kts
+++ b/chat-sdk/build.gradle.kts
@@ -63,10 +63,10 @@ android {
 }
 
 dependencies {
-    api(libs.androidxCoreKtx)
-    api(libs.androidxLifecycleRuntimeKtx)
-    api(libs.material3)
-    api(libs.runtimeLivedata)
+    compileOnly(libs.androidxCoreKtx)
+    compileOnly(libs.androidxLifecycleRuntimeKtx)
+    compileOnly(libs.runtimeLivedata)
+    compileOnly(libs.material3)
 
     // Lifecycle livedata
     implementation(libs.lifecycleLivedataKtx)
@@ -75,7 +75,7 @@ dependencies {
 
     // Retrofit
     api(libs.retrofit)
-    api(libs.okhttp)
+    implementation(libs.okhttp)
     api(libs.adapterRxjava2)
     implementation(libs.converterGson)
     implementation(libs.loggingInterceptor)
@@ -97,6 +97,8 @@ dependencies {
     // Mockito for mocking
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.inline)
+    testImplementation(libs.material3)
+    testImplementation(libs.mockk)
 
     // Kotlin extensions for Mockito
     testImplementation(libs.mockito.kotlin)
@@ -115,6 +117,11 @@ dependencies {
 tasks.withType<AbstractPublishToMaven>().configureEach {
     dependsOn(tasks.named("assembleRelease"))
 }
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
+}
+
 
 // For local publishing
 // Can be used in example app like below

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -51,6 +51,13 @@ interface ChatSession {
     suspend fun sendMessage(contentType: ContentType, message: String): Result<Boolean>
 
     /**
+     * Retry a message that failed to be sent.
+     * @param messageId The Id of the message that failed to be sent.
+     * @return A Result indicating whether the message sending was successful.
+     */
+    suspend fun resendFailedMessage(messageId: String): Result<Boolean>
+
+    /**
      * Sends an event.
      * @param event The event content.
      * @param contentType The content type of the event.
@@ -210,6 +217,12 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     override suspend fun sendMessage(contentType: ContentType, message: String): Result<Boolean> {
         return withContext(Dispatchers.IO) {
             chatService.sendMessage(contentType, message)
+        }
+    }
+
+    override suspend fun resendFailedMessage(messageId: String): Result<Boolean> {
+        return withContext(Dispatchers.IO) {
+            chatService.resendFailedMessage(messageId)
         }
     }
 

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
@@ -163,6 +163,16 @@ class ChatSessionImplTest {
     }
 
     @Test
+    fun test_resendFailedMessage_success() = runTest {
+        val messageId = "failed_message_id"
+        `when`(chatService.resendFailedMessage(messageId)).thenReturn(Result.success(true))
+
+        val result = chatSession.resendFailedMessage(messageId)
+        assertTrue(result.isSuccess)
+        verify(chatService).resendFailedMessage(messageId)
+    }
+
+    @Test
     fun test_downloadAttachment_success() = runTest {
         val attachmentId = "attachmentId"
         val filename = "filename"

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.6
+sdkVersion=1.0.7
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ hiltAndroid = "2.49"
 kotlin = "1.9.20"
 hilt = "2.49"
 materialIconsExtended = "1.7.0"
+mockk = "1.13.16"
 playServicesBasement = "18.4.0"
 robolectric = "4.13"
 serialization = "1.9.20"
@@ -70,6 +71,7 @@ composeUiTestManifest = { module = "androidx.compose.ui:ui-test-manifest", versi
 lifecycleLivedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
 lifecycleViewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 coroutinesAndroid = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutinesAndroid" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 play-services-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "playServicesBasement" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 converterGson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }


### PR DESCRIPTION
…messages, and supported auto disconnect/reconnect on background/foreground event

**Issue Number:** N/A

### Description:
*What are the changes? Why are we making them?*
* Changed the `api` dependencies into `compileOnly`or `implementation` to remove transitive dependencies that could cause conflicts at runtime. 
* Exposed method to retry undelivered text messages and attachments, and added example in App module for how to invoke it with a retry button. Also fixed a bug that the`failed` status stop showing for messages that are not sent most recently.
* Supported auto websocket disconnection/reconnection on background/foreground event (contributed by @mliao95). The logic is fully encapsulated within the SDK and enabled by default.
---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [YES]
Only added new test dependencies "mockk" for mocking static methods

---

### Testing:
*Is the code unit tested?*
Yes

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*
Yes

*List manual testing steps:*
 - Add Steps below: 
   - Looked at the dependency tree in Android Studio and made sure the transitive dependencies were removed
   - Manually started a chat and put the app in background, verified the websocket got disconnected in the client logs. Then brought the app to the foreground and verified the websocket got reconnected.
   - Manually started a 2way chat between customer and agent, sent a few messages, turned internet off on customer device, attempted to send a attachment and a text message and saw failures, hit the retry button and verified the text message and attachment were sent successfully and seen on agent CCP, with the old placeholders removed.
 
<img width="288" alt="Screenshot 2025-02-24 at 11 59 13 AM" src="https://github.com/user-attachments/assets/c970565c-6a32-4b4e-80b9-7287f72364a6" />
<img width="311" alt="Screenshot 2025-02-24 at 11 59 40 AM" src="https://github.com/user-attachments/assets/ecfa66ed-2f2d-4db0-afe5-82cee60045ac" />


Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

