### PR TITLE
Implements suspendWebSocketConnection and resumeWebSocketConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,25 @@ suspend fun disconnect(): Result<Boolean>
 
 --------------------
 
+#### `ChatSession.suspendWebSocketConnection`
+Disconnects the websocket and suspends reconnection attempts.
+
+```
+suspend fun suspendWebSocketConnection(): Result<Boolean>
+```
+
+--------------------
+
+
+#### `ChatSession.resumeWebSocketConnection`
+Resumes a suspended websocket and attempts to reconnect.
+
+```
+suspend fun resumeWebSocketConnection(): Result<Boolean>
+```
+
+--------------------
+
 #### `ChatSession.sendMessage`
 Sends a message within the chat session.
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -42,6 +42,19 @@ interface ChatSession {
      */
     suspend fun disconnect(): Result<Boolean>
 
+
+    /**
+     * Disconnects the websocket and suspends reconnection attempts.
+     * @return A Result indicating whether the suspension was successful.
+     */
+    suspend fun suspendWebSocketConnection(): Result<Boolean>
+
+    /**
+     * Resumes a suspended websocket and attempts to reconnect.
+     * @return A Result indicating whether the resume was successful.
+     */
+    suspend fun resumeWebSocketConnection(): Result<Boolean>
+
     /**
      * Sends a message.
      * @param message The message content.
@@ -211,6 +224,18 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     override suspend fun disconnect(): Result<Boolean> {
         return withContext(Dispatchers.IO) {
             chatService.disconnectChatSession()
+        }
+    }
+
+    override suspend fun suspendWebSocketConnection(): Result<Boolean> {
+        return withContext(Dispatchers.IO) {
+            chatService.suspendWebSocketConnection()
+        }
+    }
+
+    override suspend fun resumeWebSocketConnection(): Result<Boolean> {
+        return withContext(Dispatchers.IO) {
+            chatService.resumeWebSocketConnection()
         }
     }
 


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR implements and exposes two new functions, `suspendWebSocketConnection` and `resumeWebSocketConnection`.  Suspending websocket connections will disconnect the websocket and prevent any further attempts to re-establish a websocket connection.  The suspension can only be lifted by calling `resumeWebSocketConnection` which will immediately re-attempt to re-establish a connection to the active chat session.

These APIs will give customers increased flexibility in managing the websocket connection from their UI.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

Unit testing will come as fast-follow

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

Yes

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session