### PR TITLE
Exposing ConnectionDetailsProvider in ChatSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ fun configure(config: GlobalConfig)
 
 --------------------
 
+#### `ChatSession.getConnectionDetailsProvider`
+Returns a `ConnectionDetailsProvider` object that includes connection details.
+
+```
+fun getConnectionDetailsProvider(): ConnectionDetailsProvider
+```
+* Return type: [ConnectionDetailsProvider](#connectiondetailsprovider)
+
 #### `ChatSession.connect`
 Attempts to connect to a chat session with the given details.
 
@@ -479,6 +487,63 @@ data class ChatDetails(
   * Participant token received via [StartChatContact](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartChatContact.html) response
   * Type: `String`
 ---------------------
+
+### ConnectionDetailsProvider
+
+```
+interface ConnectionDetailsProvider {
+    fun updateChatDetails(newDetails: ChatDetails)
+    fun getConnectionDetails(): ConnectionDetails?
+    fun updateConnectionDetails(newDetails: ConnectionDetails)
+    fun getChatDetails(): ChatDetails?
+    fun isChatSessionActive(): Boolean
+    fun setChatSessionState(isActive: Boolean)
+}
+```
+* `updateChatDetails`
+  * Updates chat details
+  * newDetails
+    * Type: `ChatDetails`
+* `getConnectionDetails`
+  * Gets connection details received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Return type: [ConnectionDetails](#connectiondetails)
+* `updateConnectionDetails`
+  * Updates connection details 
+  * newDetails
+    * Type: [ConnectionDetails](#connectiondetails)
+* `getChatDetails`
+  * Gets chat details
+  * Return type: `ChatDetails`
+* `isChatSessionActive`
+  * Gets chat session active state
+  * Return type: Boolean
+* `setChatSessionState`
+  * Sets chat session state
+  * isActive
+    * Type: Boolean
+
+---------------------
+
+### ConnectionDetails
+
+```
+data class ConnectionDetails(
+    val websocketUrl: String,
+    val connectionToken: String,
+    val expiry: String
+)
+```
+* `websocketUrl`
+  * URL of the websocket received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Type: `String`
+* `connectionToken`
+  * Connection token received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Type: `String`
+* `expiry`
+  * Expiration of the token received via [CreateParticipantConnection](https://docs.aws.amazon.com/connect/latest/APIReference/API_connect-participant_CreateParticipantConnection.html) response
+  * Type: `String`
+---------------------
+
 ### ContentType
 
 `ContentType` describe the type of events and messages that come through the WebSocket.

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -13,6 +13,7 @@ import com.amazon.connect.chat.sdk.model.MessageReceiptType
 import com.amazon.connect.chat.sdk.model.MessageStatus
 import com.amazon.connect.chat.sdk.model.TranscriptItem
 import com.amazon.connect.chat.sdk.model.TranscriptResponse
+import com.amazon.connect.chat.sdk.provider.ConnectionDetailsProvider
 import com.amazon.connect.chat.sdk.repository.ChatService
 import com.amazonaws.services.connectparticipant.model.ScanDirection
 import com.amazonaws.services.connectparticipant.model.SortKey
@@ -29,6 +30,13 @@ import javax.inject.Singleton
 
 interface ChatSession {
     fun configure(config: GlobalConfig)
+
+    /**
+     *  Returns ConnectionDetailsProvider object
+     *  @return ConnectionDetailsProvider object that includes connection details.
+     */
+    fun getConnectionDetailsProvider(): ConnectionDetailsProvider
+
     /**
      * Connects to a chat session with the specified chat details.
      * @param chatDetails The details of the chat.
@@ -198,6 +206,10 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
 
     override fun configure(config: GlobalConfig) {
         chatService.configure(config)
+    }
+
+    override fun getConnectionDetailsProvider(): ConnectionDetailsProvider {
+        return chatService.getConnectionDetailsProvider()
     }
 
     override suspend fun connect(chatDetails: ChatDetails): Result<Boolean> {

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -52,6 +52,8 @@ interface ChatService {
 
     fun configure(config: GlobalConfig)
 
+    fun getConnectionDetailsProvider(): ConnectionDetailsProvider
+
     /**
      * Creates a chat session with the specified chat details.
      * @param chatDetails The details of the chat.
@@ -186,6 +188,10 @@ class ChatServiceImpl @Inject constructor(
     override fun configure(config: GlobalConfig) {
         awsClient.configure(config)
         metricsManager.configure(config)
+    }
+
+    override fun getConnectionDetailsProvider(): ConnectionDetailsProvider {
+        return connectionDetailsProvider
     }
 
     init {

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
@@ -14,6 +14,7 @@ import com.amazon.connect.chat.sdk.repository.ChatService
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.connectparticipant.model.ScanDirection
 import com.amazonaws.services.connectparticipant.model.SortKey
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -48,6 +49,12 @@ class ChatSessionImplTest {
         val config = GlobalConfig(region = Regions.US_WEST_2)
         chatSession.configure(config)
         verify(chatService).configure(config)
+    }
+
+    @Test
+    fun test_getConnectionDetailsProvider(){
+        chatSession.getConnectionDetailsProvider()
+        verify(chatService).getConnectionDetailsProvider()
     }
 
     @Test

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -117,6 +117,12 @@ class ChatServiceImplTest {
     }
 
     @Test
+    fun test_getConnectionDetailsProvider(){
+        val result = chatService.getConnectionDetailsProvider()
+        assertEquals(result, connectionDetailsProvider)
+    }
+
+    @Test
     fun test_createParticipantConnection_success() = runTest {
         val chatDetails = ChatDetails(participantToken = "token")
         val mockConnectionDetails = createMockConnectionDetails("valid_token")


### PR DESCRIPTION
**Issue Number:**
N/A

### Description:
*What are the changes? Why are we making them?*
Exposing ConnectionDetailsProvider in ChatSession

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?*
Yes

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*
Yes

*List manual testing steps:*
 - Add Steps below: 
Manually tested calling `chatSession.getConnectionDetailsProvider().getConnectionDetails()` and verified the connection token was received. Also verified a new connection token is received after background/foreground events.

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

