### PR TITLE
Remove MessageStatus.Custom and support customValue in MessageStatus.…

### DIFF
--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/utils/CommonUtils.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/utils/CommonUtils.kt
@@ -102,14 +102,13 @@ object CommonUtils {
             MessageStatus.Delivered -> "Delivered"
             MessageStatus.Read -> "Read"
             MessageStatus.Sending -> "Sending"
-            MessageStatus.Failed -> "Failed to send"
+            MessageStatus.Failed -> status.customValue ?: "Failed to send"
             MessageStatus.Sent -> "Sent"
-            MessageStatus.Custom -> status.customValue ?: "Custom status"
             else -> ""  // Returning empty string for unknown or null status
         }
     }
 
-    fun retryButtonEnabled(status: String): Boolean {
-        return !arrayOf("Delivered", "Read", "Sending", "Sent").contains(status)
+    fun retryButtonEnabled(status: MessageStatus?): Boolean {
+        return status == MessageStatus.Failed
     }
 }

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/AttachmentMessageView.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/AttachmentMessageView.kt
@@ -147,7 +147,7 @@ fun AttachmentMessageView(
             }
 
             // display message status only when the message wasn't sent successfully, or it is the recent outgoing message
-            val retryEnabled = retryButtonEnabled(CommonUtils.customMessageStatus(message.metadata?.status))
+            val retryEnabled = retryButtonEnabled(message.metadata?.status)
             if (message.messageDirection == MessageDirection.OUTGOING && (message.id == recentOutgoingMessageID || retryEnabled)) {
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/ChatComponents.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/views/ChatComponents.kt
@@ -144,7 +144,7 @@ fun SenderChatBubble(message: Message, recentOutgoingMessageID: String? = null, 
             }
 
             message.metadata?.status?.let {
-                val retryEnabled = retryButtonEnabled(it.status)
+                val retryEnabled = retryButtonEnabled(it)
                 // display message status only when the message wasn't sent successfully, or it is the recent outgoing message
                 if (message.id == recentOutgoingMessageID || retryEnabled) {
                     Text(

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/MessageMetadata.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/MessageMetadata.kt
@@ -9,14 +9,12 @@ enum class MessageStatus(val status: String, var customValue: String? = null) {
     Sending("Sending"),
     Failed("Failed"),
     Sent("Sent"),
-    Unknown("Unknown"),
-
-    Custom("Custom", null);
+    Unknown("Unknown");
 
     companion object {
-        fun custom(message: String): MessageStatus {
-            return Custom.apply {
-                Custom.customValue = message
+        fun customFailed(message: String): MessageStatus {
+            return Failed.apply {
+                Failed.customValue = message
             }
         }
     }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -525,7 +525,7 @@ class ChatServiceImpl @Inject constructor(
         val oldMessage = transcriptDict[messageId] as? Message
 
         // cannot retry if old message didn't exist or fail to be sent
-        if (oldMessage == null || !arrayOf(MessageStatus.Failed, MessageStatus.Custom, MessageStatus.Unknown).contains(oldMessage.metadata?.status)) {
+        if (oldMessage == null || MessageStatus.Failed != oldMessage.metadata?.status) {
             return Result.failure(Exception("Unable to find the failed message"))
         }
 
@@ -668,7 +668,7 @@ class ChatServiceImpl @Inject constructor(
             SDKLogger.logger.logError { "Failed to send attachment: ${exception.message}" }
             recentlySentAttachmentMessage?.let {
                 it.metadata?.status =
-                    MessageStatus.custom(exception.message ?: "Failed to send attachment")
+                    MessageStatus.customFailed(exception.message ?: "Failed to send attachment")
                 sendSingleUpdateToClient(it)
                 SDKLogger.logger.logError { "Message status updated to Failed: $it" }
             }


### PR DESCRIPTION
…Failed

**Issue Number:** N/A

### Description:
*What are the changes? Why are we making them?*

Remove `MessageStatus.Custom`, support adding `customValue` in `MessageStatus.Failed` instead. This behavior is consistent in iOS sdk

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?*
N/A

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*
Yes

*List manual testing steps:*
 - Add Steps below: 
Tested basic functionalities and new features added recently (resending undelivered messages)

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

