### PR TITLE
Fix interactive message models and getTranscript not parsing interact…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           build-tools: 30.0.3
 
       - name: Cache Gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -64,7 +64,7 @@ jobs:
           build-tools: 30.0.3
 
       - name: Cache Gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/MessageContent.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/MessageContent.kt
@@ -41,8 +41,14 @@ data class QuickReplyContentData(
     val elements: List<QuickReplyElement>
 )
 @Serializable
+data class QuickReplyReplyMessage(
+    val title: String,
+    val subtitle: String? = null
+)
+@Serializable
 data class QuickReplyData(
-    val content: QuickReplyContentData
+    val content: QuickReplyContentData,
+    val replyMessage: QuickReplyReplyMessage? = null,
 )
 @Serializable
 data class QuickReplyTemplate(
@@ -90,12 +96,19 @@ data class ListPickerContentData(
     val elements: List<ListPickerElement>
 )
 @Serializable
+data class ListPickerReplyMessage(
+    val title: String,
+    val subtitle: String? = null
+)
+@Serializable
 data class ListPickerData(
-    val content: ListPickerContentData
+    val content: ListPickerContentData,
+    val replyMessage: ListPickerReplyMessage? = null,
 )
 @Serializable
 data class ListPickerTemplate(
     val templateType: String,
+    val templateIdentifier: String,
     val version: String,
     val data: ListPickerData
 )

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
@@ -88,15 +88,14 @@ object TranscriptItemUtils {
                 "isFromPastSession" to true // Mark all these items as coming from a past session
             )
 
+            val messageContent = mapOf(
+                "content" to messageContentDict
+            )
             // Serialize the dictionary to JSON string
-            val messageContentString = JSONObject(messageContentDict).toString()
-
-            // Wrap the JSON string
-            val wrappedMessageString =
-                "{\"content\":\"${messageContentString.replace("\"", "\\\"")}\"}"
+            val messageContentString = JSONObject(messageContent).toString()
 
             // Deserialize back to JSON object
-            val json = JSONObject(wrappedMessageString)
+            val json = JSONObject(messageContentString)
 
             json.optString("content")
         } catch (e: Exception) {

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtilsTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtilsTest.kt
@@ -1,0 +1,39 @@
+package com.amazon.connect.chat.sdk.utils
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.junit.Test
+import org.junit.Assert.assertNotNull
+import com.amazonaws.services.connectparticipant.model.Item
+
+
+@RunWith(RobolectricTestRunner::class)
+class TranscriptItemUtilsTest {
+    private val INTERACTIVE_MESSAGE_CONTENTS = arrayOf(
+        // List Picker
+        "{\"templateIdentifier\":\"uuid\",\"templateType\":\"ListPicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\",\"subtitle\":\"\$1.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/apple.jpg\"},{\"title\":\"Orange\",\"subtitle\":\"\$1.50\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/orange.jpg\"},{\"title\":\"Banana\",\"subtitle\":\"\$2.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/banana.jpg\"}]}}}",
+        // Time Picker
+        "{\"templateType\":\"TimePicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"Schedule appointment\",\"subtitle\":\"Tap to select option\",\"timeslots\":[{\"date\":\"2026-01-02T00:00+00:00\",\"duration\":60},{\"date\":\"2026-01-03T00:00+00:00\",\"duration\":60},{\"date\":\"2026-01-04T00:00+00:00\",\"duration\":60}],\"location\":{\"title\":\"Oscar\",\"latitude\":47.616299,\"longitude\":-122.333031,\"radius\":1},\"timeZoneOffset\":-420}}}",
+        // Panel
+        "{\"templateIdentifier\":\"uuid\",\"templateType\":\"Panel\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\"},{\"title\":\"Orange\"},{\"title\":\"Banana\"}]}}}",
+        // Quick Reply
+        "{\"templateType\":\"QuickReply\",\"version\":\"1.0\",\"data\":{\"replyMessage\":{\"title\":\"Thanks for selecting!\"},\"content\":{\"title\":\"How was your experience?\",\"elements\":[{\"title\":\"Great\"},{\"title\":\"Good\"},{\"title\":\"Ok\"},{\"title\":\"Poor\"},{\"title\":\"Terrible\"}]}}}",
+        // Carousel
+        "{\"templateType\":\"Carousel\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"Select from produce carousel\",\"omitTitleFromCarouselResponse\":false,\"elements\":[{\"templateIdentifier\":\"interactiveCarousel001\",\"templateType\":\"ListPicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\",\"subtitle\":\"\$1.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/apple.jpg\"},{\"title\":\"Orange\",\"subtitle\":\"\$1.50\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/orange.jpg\"},{\"title\":\"Banana\",\"subtitle\":\"\$2.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/banana.jpg\"}]}}},{\"templateIdentifier\":\"interactiveCarousel002\",\"templateType\":\"ListPicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\",\"subtitle\":\"\$1.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/apple.jpg\"},{\"title\":\"Orange\",\"subtitle\":\"\$1.50\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/orange.jpg\"},{\"title\":\"Banana\",\"subtitle\":\"\$2.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/banana.jpg\"}]}}},{\"templateIdentifier\":\"interactiveCarousel003\",\"templateType\":\"ListPicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\",\"subtitle\":\"\$1.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/apple.jpg\"},{\"title\":\"Orange\",\"subtitle\":\"\$1.50\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/orange.jpg\"},{\"title\":\"Banana\",\"subtitle\":\"\$2.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/banana.jpg\"}]}}},{\"templateIdentifier\":\"interactiveCarousel004\",\"templateType\":\"ListPicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\",\"subtitle\":\"\$1.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/apple.jpg\"},{\"title\":\"Orange\",\"subtitle\":\"\$1.50\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/orange.jpg\"},{\"title\":\"Banana\",\"subtitle\":\"\$2.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/banana.jpg\"}]}}},{\"templateIdentifier\":\"interactiveCarousel005\",\"templateType\":\"ListPicker\",\"version\":\"1.0\",\"data\":{\"content\":{\"title\":\"What produce would you like to buy?\",\"subtitle\":\"Tap to select option\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/fruits.jpg\",\"elements\":[{\"title\":\"Apple\",\"subtitle\":\"\$1.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/apple.jpg\"},{\"title\":\"Orange\",\"subtitle\":\"\$1.50\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/orange.jpg\"},{\"title\":\"Banana\",\"subtitle\":\"\$2.00\",\"imageType\":\"URL\",\"imageData\":\"https://undefined.s3.undefined.amazonaws.com/banana.jpg\"}]}}}]}}}"
+    )
+
+    @Test
+    fun test_serializeTranscriptItem(){
+        INTERACTIVE_MESSAGE_CONTENTS.forEach { content ->
+            val item = Item()
+                .withId("e1d3bc93-fc72-421b-95f6-13b37626668b")
+                .withContent(content)
+                .withContentType("application/vnd.amazonaws.connect.message.interactive")
+                .withParticipantId("c8528570-62e6-47d9-ab5d-b6e152a07935")
+                .withParticipantRole("SYSTEM")
+                .withType("MESSAGE")
+            val result = TranscriptItemUtils.serializeTranscriptItem(item)
+            assertNotNull(result)
+        }
+    }
+}


### PR DESCRIPTION
…ive messages correctly

**Issue Number:** 
N/A

### Description:
*What are the changes? Why are we making them?*
- Updated interactive message content models, added optional ListPickerReplyMessage and QuickReplyReplyMessage which were missing and causing de-serialization to fail
- Fixed serializing and de-serializing logic in TranscriptItemUtils.serializeTranscriptItem() method. Previously it manually mutates the JSON string that caused unexpected behavior and invalid JSON which thrown an error when converted into object. This was eventually causing the interactive message to be filtered out in getTranscript.   
- Added unit test for TranscriptItemUtils.serializeTranscriptItem() method
- bumped version of github actions/cache to v4 as v2 is deprecated


---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?*
Yes

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*
Yes

*List manual testing steps:*
 - Add Steps below: 
 - Started a chat with interactive message flow, and invoke bot actions to return interactive messages
 - Verified interactive message was received correctly over web-socket
 - Reopen the app to trigger a getTranscript API call, verified the interactive message was received correctly in the API response and not filtered out 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

