### PR TITLE
Implementing UserAgent suffix for Connect Participant APIs

### DIFF
--- a/chat-sdk/build.gradle.kts
+++ b/chat-sdk/build.gradle.kts
@@ -1,3 +1,9 @@
+import java.util.Properties
+
+val versionProperties = Properties().apply {
+    file("version.properties").inputStream().use { load(it) }
+}
+
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
@@ -11,6 +17,9 @@ plugins {
 android {
     namespace = "com.amazon.connect.chat.sdk"
     compileSdk = 34
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
         minSdk = 24
@@ -18,6 +27,7 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        buildConfigField("String", "SDK_VERSION", "\"${versionProperties["sdkVersion"]}\"")
     }
 
     buildTypes {

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/di/NetworkModule.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/di/NetworkModule.kt
@@ -16,6 +16,7 @@ import com.amazon.connect.chat.sdk.repository.MessageReceiptsManager
 import com.amazon.connect.chat.sdk.repository.MessageReceiptsManagerImpl
 import com.amazon.connect.chat.sdk.repository.MetricsManager
 import com.amazon.connect.chat.sdk.utils.MetricsUtils.getMetricsEndpoint
+import com.amazon.connect.chat.sdk.utils.CommonUtils
 import com.amazonaws.services.connectparticipant.AmazonConnectParticipantClient
 import dagger.Module
 import dagger.Provides
@@ -113,7 +114,8 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideAmazonConnectParticipantClient(): AmazonConnectParticipantClient {
-        return AmazonConnectParticipantClient()
+        val clientConfiguration = CommonUtils.createConnectParticipantConfiguration()
+        return AmazonConnectParticipantClient(clientConfiguration)
     }
 
     /**

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AWSClient.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/AWSClient.kt
@@ -6,6 +6,7 @@ package com.amazon.connect.chat.sdk.network
 import com.amazon.connect.chat.sdk.model.ConnectionDetails
 import com.amazon.connect.chat.sdk.model.ContentType
 import com.amazon.connect.chat.sdk.model.GlobalConfig
+import com.amazon.connect.chat.sdk.utils.CommonUtils
 import com.amazon.connect.chat.sdk.utils.Constants
 import com.amazonaws.regions.Region
 import com.amazonaws.services.connectparticipant.AmazonConnectParticipantClient
@@ -111,8 +112,8 @@ class AWSClientImpl @Inject constructor(
     companion object {
         fun create(): AWSClient {
             // Create an AmazonConnectParticipantClient
-            val connectParticipantClient = AmazonConnectParticipantClient()
-
+            val clientConfiguration = CommonUtils.createConnectParticipantConfiguration()
+            val connectParticipantClient = AmazonConnectParticipantClient(clientConfiguration)
             return AWSClientImpl(connectParticipantClient)
         }
     }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/CommonUtils.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/CommonUtils.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.amazon.connect.chat.sdk.BuildConfig
+import com.amazonaws.ClientConfiguration
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -69,6 +71,14 @@ class CommonUtils {
         fun getMimeType(fileName: String): String {
             val extension = fileName.substringAfterLast('.', "")
             return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: "*/*"
+        }
+
+        fun createConnectParticipantConfiguration(): ClientConfiguration {
+            val clientConfiguration = ClientConfiguration()
+            val originalUserAgent: String = clientConfiguration.getUserAgent()
+            val userAgentSuffix = "AmazonConnect-Mobile Chat-Android SDK/" + BuildConfig.SDK_VERSION
+            clientConfiguration.userAgent = "$originalUserAgent $userAgentSuffix"
+            return clientConfiguration
         }
     }
 


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR implements a user agent suffix for ACPS calls using the Connect Participant client.  Here is an example user agent string from this SDK:

```
aws-sdk-android/2.22.6 Linux/4.4.302-gcc24b0a8f68a Dalvik/2.1.0/0 en_US aws-sdk-android/2.22.6 Linux/4.4.302-gcc24b0a8f68a Dalvik/2.1.0/0 en_US AmazonConnect-Mobile Chat-Android SDK/1.0.7
```

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO] NO

*Does this change introduce any new dependency?* [YES/NO]. NO

---

### Testing:
*Is the code unit tested?*

NA

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

NA

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

