### PR TITLE
Implementing ChatSession.reset API

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ suspend fun resumeWebSocketConnection(): Result<Boolean>
 
 --------------------
 
+#### `ChatSession.reset`
+Resets the ChatSession object which will disconnect the webSocket and remove all session related data without disconnected the participant from the chat contact.
+
+```
+suspend fun reset(): Result<Boolean>
+```
+
+--------------------
+
 #### `ChatSession.sendMessage`
 Sends a message within the chat session.
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ suspend fun resumeWebSocketConnection(): Result<Boolean>
 --------------------
 
 #### `ChatSession.reset`
-Resets the ChatSession object which will disconnect the webSocket and remove all session related data without disconnected the participant from the chat contact.
+Resets the ChatSession object which will disconnect the webSocket and remove all session related data without disconnecting the participant from the chat contact.
 
 ```
 suspend fun reset(): Result<Boolean>

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
@@ -3,9 +3,9 @@ package com.amazon.connect.chat.androidchatexample
 import com.amazonaws.regions.Regions
 
 object Config {
-    val connectInstanceId: String = ""
-    val contactFlowId: String = ""
-    val startChatEndpoint: String = "https://<endpoint>.execute-api.<region>.amazonaws.com/Prod/"
+    val connectInstanceId: String = "e816d0f3-eda3-46e4-bc67-9999e621eff6"
+    val contactFlowId: String = "f22bfa3b-400e-4250-939d-90a79eb1cd24"
+    val startChatEndpoint: String = "https://bqo00ujzld.execute-api.us-west-2.amazonaws.com/Prod"
     val region: Regions = Regions.US_WEST_2
     val agentName = "AGENT"
     val customerName = "CUSTOMER"

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
@@ -3,9 +3,9 @@ package com.amazon.connect.chat.androidchatexample
 import com.amazonaws.regions.Regions
 
 object Config {
-    val connectInstanceId: String = "e816d0f3-eda3-46e4-bc67-9999e621eff6"
-    val contactFlowId: String = "f22bfa3b-400e-4250-939d-90a79eb1cd24"
-    val startChatEndpoint: String = "https://bqo00ujzld.execute-api.us-west-2.amazonaws.com/Prod"
+    val connectInstanceId: String = ""
+    val contactFlowId: String = ""
+    val startChatEndpoint: String = "https://<endpoint>.execute-api.<region>.amazonaws.com/Prod/"
     val region: Regions = Regions.US_WEST_2
     val agentName = "AGENT"
     val customerName = "CUSTOMER"

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -64,6 +64,12 @@ interface ChatSession {
     suspend fun resumeWebSocketConnection(): Result<Boolean>
 
     /**
+     * Resets the current state which will disconnect the webSocket and remove all session related data.
+     * @return A Result indicating whether the reset was successful.
+     */
+    suspend fun reset(): Result<Boolean>
+
+    /**
      * Sends a message.
      * @param message The message content.
      * @param contentType The content type of the message.
@@ -248,6 +254,14 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     override suspend fun resumeWebSocketConnection(): Result<Boolean> {
         return withContext(Dispatchers.IO) {
             chatService.resumeWebSocketConnection()
+        }
+    }
+
+    override suspend fun reset(): Result<Boolean> {
+        return withContext(Dispatchers.IO) {
+            cleanup()
+            isChatSessionActive = false
+            chatService.reset()
         }
     }
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -64,7 +64,7 @@ interface ChatSession {
     suspend fun resumeWebSocketConnection(): Result<Boolean>
 
     /**
-     * Resets the current state which will disconnect the webSocket and remove all session related data.
+     * Resets the current state which will disconnect the webSocket and remove all session related data without disconnecting the participant from the chat contact.
      * @return A Result indicating whether the reset was successful.
      */
     suspend fun reset(): Result<Boolean>

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -381,11 +381,11 @@ class WebSocketManagerImpl @Inject constructor(
             return
         }
         if (isChatSuspended) {
-            Log.d("WebSocket", "Re-connection aborted due suspended chat session.")
+            Log.d("WebSocket", "Re-connection aborted due to suspended chat session.")
             return
         }
         if (_isReconnecting.value) {
-            Log.d("WebSocket", "Re-connection aborted due ongoing reconnection attempt.")
+            Log.d("WebSocket", "Re-connection aborted due to ongoing reconnection attempt.")
             return
         }
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/provider/ConnectionDetailProvider.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/provider/ConnectionDetailProvider.kt
@@ -17,6 +17,7 @@ interface ConnectionDetailsProvider {
     fun getChatDetails(): ChatDetails?
     fun isChatSessionActive(): Boolean
     fun setChatSessionState(isActive: Boolean)
+    fun reset()
     var chatSessionState: StateFlow<Boolean>
 }
 
@@ -54,5 +55,11 @@ class ConnectionDetailsProviderImpl @Inject constructor() : ConnectionDetailsPro
 
     override fun setChatSessionState(isActive: Boolean) {
         _chatSessionState.value = isActive
+    }
+
+    override fun reset() {
+        connectionDetails = null
+        chatDetails = null
+        setChatSessionState(false)
     }
 }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -80,7 +80,7 @@ interface ChatService {
     suspend fun resumeWebSocketConnection(): Result<Boolean>
 
     /**
-     * Resets the current state which will disconnect the webSocket and remove all session related data.
+     * Resets the current state which will disconnect the webSocket and remove all session related data without disconnecting the participant from the chat contact.
      * @return A Result indicating whether the reset was successful.
      */
     suspend fun reset(): Result<Boolean>


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR introduces a new API: `ChatSession.reset`.  This API will remove all in-memory user session data such as internal transcript and tokens.  This will also disconnect the websocket connection.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

