### PR TITLE
Adding interactive response contentType

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
@@ -14,7 +14,8 @@ enum class ContentType(val type: String){
     ENDED("application/vnd.amazonaws.connect.event.chat.ended"),
     PLAIN_TEXT("text/plain"),
     RICH_TEXT("text/markdown"),
-    INTERACTIVE_TEXT("application/vnd.amazonaws.connect.message.interactive");
+    INTERACTIVE_TEXT("application/vnd.amazonaws.connect.message.interactive"),
+    INTERACTIVE_RESPONSE("application/vnd.amazonaws.connect.message.interactive.response");
 
     companion object {
         fun fromType(type: String): ContentType? {


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

Adding interactive response contentType:
`application/vnd.amazonaws.connect.message.interactive.response`

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

NA

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

