### PR TITLE
Fixing ChatSession.reset

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -258,9 +258,9 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     }
 
     override suspend fun reset(): Result<Boolean> {
+        cleanup()
+        isChatSessionActive = false
         return withContext(Dispatchers.IO) {
-            cleanup()
-            isChatSessionActive = false
             chatService.reset()
         }
     }

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.7
+sdkVersion=1.0.8
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

Moving `cleanup()` to the main thread in `ChatSession`.  Since `cleanup()` triggers the `onChatSessionStateChanged` event handler, customers that hook on to that event and call `setValue` will need that executed on the main thread.

The previous code was grouping `cleanup()` with the asynchronous `chatService.reset` call which forced `cleanup` to run on the background thread, where users cannot hook onto the event to modify values using `setValue`.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

