### PR TITLE
Fixing issue that message metadata is missing in getTranscript

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -13,6 +13,7 @@ import com.amazon.connect.chat.sdk.model.Event
 import com.amazon.connect.chat.sdk.model.Message
 import com.amazon.connect.chat.sdk.model.MessageDirection
 import com.amazon.connect.chat.sdk.model.MessageMetadata
+import com.amazon.connect.chat.sdk.model.MessageMetadataProtocol
 import com.amazon.connect.chat.sdk.model.MessageStatus
 import com.amazon.connect.chat.sdk.model.TranscriptItem
 import com.amazon.connect.chat.sdk.model.WebSocketMessageType
@@ -421,7 +422,9 @@ class WebSocketManagerImpl @Inject constructor(
             timeStamp = time,
             id = messageId,
             displayName = displayName,
-            serializedContent = rawData
+            serializedContent = rawData,
+            metadata = if (innerJson.has("MessageMetadata"))
+                    (handleMetadata(innerJson, rawData) as? MessageMetadataProtocol) else null
         )
         return message
     }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
@@ -76,6 +76,21 @@ object TranscriptItemUtils {
                 )
             } ?: emptyList()
 
+            var messageMetadataDict: Map<String, Any>? = null
+            if (item.messageMetadata != null) {
+                val receiptsArray = item.messageMetadata?.receipts?.map { receipt ->
+                    mapOf(
+                        "ReadTimestamp" to (receipt.readTimestamp ?: ""),
+                        "DeliveredTimestamp" to (receipt.deliveredTimestamp ?: ""),
+                        "RecipientParticipantId" to (receipt.recipientParticipantId ?: "")
+                    )
+                } ?: emptyList()
+                messageMetadataDict = mapOf(
+                    "MessageId" to item.messageMetadata.messageId,
+                    "Receipts" to receiptsArray
+                )
+            }
+
             val messageContentDict = mapOf(
                 "Id" to (item.id ?: ""),
                 "ParticipantRole" to participantRole,
@@ -85,7 +100,8 @@ object TranscriptItemUtils {
                 "Type" to item.type,
                 "DisplayName" to (item.displayName ?: ""),
                 "Attachments" to attachmentsArray,
-                "isFromPastSession" to true // Mark all these items as coming from a past session
+                "isFromPastSession" to true, // Mark all these items as coming from a past session
+                "MessageMetadata" to messageMetadataDict
             )
 
             val messageContent = mapOf(


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*
Fixing issue that message metadata is missing in getTranscript

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [NO]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?*
No

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*
Yes

*List manual testing steps:*
 - Add Steps below: 
   - started a chat a accepted from agent CCP
   - sent messages from customer and read them from CCP, confirmed read receipts were displayed
   - closed the app, then opened it again and reconnected to the existing chat to trigger a getTranscript, verified read receipts were still there

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

