### PR TITLE
Adding additional events to ContentType + Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Last updated: April 2025
+# Team: https://github.com/orgs/amazon-connect/teams/blitz
+
+* @amazon-connect/blitz

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
@@ -15,7 +15,23 @@ enum class ContentType(val type: String){
     PLAIN_TEXT("text/plain"),
     RICH_TEXT("text/markdown"),
     INTERACTIVE_TEXT("application/vnd.amazonaws.connect.message.interactive"),
-    INTERACTIVE_RESPONSE("application/vnd.amazonaws.connect.message.interactive.response");
+    INTERACTIVE_RESPONSE("application/vnd.amazonaws.connect.message.interactive.response"),
+    AUTHENTICATION_INITIATED("application/vnd.amazonaws.connect.event.authentication.initiated"),
+    AUTHENTICATION_SUCCESSFUL("application/vnd.amazonaws.connect.event.authentication.succeeded"),
+    AUTHENTICATION_FAILED("application/vnd.amazonaws.connect.event.authentication.failed"),
+    AUTHENTICATION_TIMEOUT("application/vnd.amazonaws.connect.event.authentication.timeout"),
+    AUTHENTICATION_EXPIRED("application/vnd.amazonaws.connect.event.authentication.expired"),
+    AUTHENTICATION_CANCELLED("application/vnd.amazonaws.connect.event.authentication.cancelled"),
+    PARTICIPANT_DISPLAY_NAME_UPDATED("application/vnd.amazonaws.connect.event.participant.displayname.updated"),
+    PARTICIPANT_ACTIVE("application/vnd.amazonaws.connect.event.participant.active"),
+    PARTICIPANT_INACTIVE("application/vnd.amazonaws.connect.event.participant.inactive"),
+    TRANSFER_SUCCEEDED("application/vnd.amazonaws.connect.event.transfer.succeeded"),
+    TRANSFER_FAILED("application/vnd.amazonaws.connect.event.transfer.failed"),
+    PARTICIPANT_IDLE("application/vnd.amazonaws.connect.event.participant.idle"),
+    PARTICIPANT_RETURNED("application/vnd.amazonaws.connect.event.participant.returned"),
+    PARTICIPANT_INVITED("application/vnd.amazonaws.connect.event.participant.invited"),
+    AUTO_DISCONNECTION("application/vnd.amazonaws.connect.event.participant.autodisconnection"),
+    CHAT_REHYDRATED("application/vnd.amazonaws.connect.event.chat.rehydrated");
 
     companion object {
         fun fromType(type: String): ContentType? {


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR updates the list of chat events to cover additional scenarios such as authentication, idle, transfers and chat re-hydration.

This PR also adds a `CODEOWNERS` file so that reviewers are auto-assigned upon PR creation.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

NA

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

NA

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

