### PR TITLE
Fixing getTranscript loop on reconnection flow

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -744,13 +744,9 @@ class ChatServiceImpl @Inject constructor(
             sortKey = SortKey.ASCENDING,
             maxResults = 100,
             nextToken = null).onSuccess { transcriptResponse ->
-            if (transcriptResponse.nextToken?.isNotEmpty() == true) {
-                val lastItem = transcriptResponse.transcript.lastOrNull()
-                val newStartPosition = lastItem?.let {
-                    StartPosition().apply {
-                        id = it.id
-                    }
-                }
+            val lastItem = transcriptResponse.transcript.lastOrNull()
+            if (transcriptResponse.nextToken?.isNotEmpty() == true && lastItem != null) {
+                val newStartPosition = StartPosition().apply { id = lastItem.id }
                 if (!isItemInInternalTranscript(lastItem?.id)) {
                     fetchTranscriptWith(startPosition = newStartPosition)
                 }

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -18,6 +18,7 @@ import com.amazon.connect.chat.sdk.provider.ConnectionDetailsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.connectparticipant.model.DisconnectParticipantResult
 import com.amazonaws.services.connectparticipant.model.GetTranscriptResult
+import com.amazonaws.services.connectparticipant.model.Item
 import com.amazonaws.services.connectparticipant.model.ScanDirection
 import com.amazonaws.services.connectparticipant.model.SendEventResult
 import com.amazonaws.services.connectparticipant.model.SendMessageResult
@@ -48,6 +49,12 @@ import org.robolectric.RobolectricTestRunner
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import junit.framework.TestCase.fail
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.setMain
+import org.mockito.kotlin.any
 import java.util.UUID
 import java.net.URL
 
@@ -76,7 +83,7 @@ class ChatServiceImplTest {
     @Mock
     private lateinit var messageReceiptsManager: MessageReceiptsManager
 
-    private lateinit var chatService: ChatService
+    private lateinit var chatService: ChatServiceImpl
     private lateinit var eventSharedFlow: MutableSharedFlow<ChatEvent>
     private lateinit var transcriptSharedFlow: MutableSharedFlow<TranscriptItem>
     private lateinit var chatSessionStateFlow: MutableStateFlow<Boolean>
@@ -84,10 +91,12 @@ class ChatServiceImplTest {
     private lateinit var newWsUrlFlow: MutableSharedFlow<Unit>
 
     private val mockUri: Uri = Uri.parse("https://example.com/dummy.pdf")
+    private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
 
         eventSharedFlow = MutableSharedFlow()
         transcriptSharedFlow = MutableSharedFlow()
@@ -510,6 +519,48 @@ class ChatServiceImplTest {
         verify(awsClient).getTranscript(anyOrNull())
     }
 
+    private fun createMockItem(id: String, timestamp: String): Item {
+        val item = Item()
+        item.absoluteTime = timestamp
+        item.content = "test${id}"
+        item.contentType = "text/plain"
+        item.id = id
+        item.type = "MESSAGE"
+        item.participantId = id
+        item.displayName = "test${id}"
+        item.participantRole = "CUSTOMER"
+        return item
+    }
+
+    @Test
+    fun test_fetchReconnectedTranscript_success() = runTest {
+        val chatDetails = ChatDetails(participantToken = "token")
+        val mockConnectionDetails = createMockConnectionDetails("valid_token")
+        `when`(connectionDetailsProvider.getConnectionDetails()).thenReturn(mockConnectionDetails)
+        chatService.createChatSession(chatDetails)
+        advanceUntilIdle()
+
+        // Create a mock GetTranscriptResult and configure it to return expected values
+        val mockGetTranscriptResult = mock<GetTranscriptResult>()
+
+        `when`(mockGetTranscriptResult.initialContactId).thenReturn("")
+        `when`(awsClient.getTranscript(anyOrNull())).thenReturn(Result.success(mockGetTranscriptResult))
+
+        // Add items to the internal transcript and emit reconnection event.
+        // This scenario should call getTranscript twice since nextToken is defined in the first call.
+        `when`(mockGetTranscriptResult.transcript).thenReturn(listOf())
+        `when`(mockGetTranscriptResult.nextToken).thenReturn("nextToken1").thenReturn("")
+
+        val transcriptItem1 = Message(id = "1", timeStamp = "2024-01-01T00:00:00Z", participant = "user", contentType = "text/plain", text = "Hello")
+        val transcriptItem2 = Message(id = "2", timeStamp = "2025-01-01T00:01:00Z", participant = "agent", contentType = "text/plain", text = "Hi")
+        chatService.internalTranscript.add(transcriptItem1)
+        chatService.internalTranscript.add(transcriptItem2)
+        val chatEvent = ChatEvent.ConnectionReEstablished
+        eventSharedFlow.emit(chatEvent)
+        advanceUntilIdle()
+        verify(awsClient, times(2)).getTranscript(anyOrNull())
+    }
+
     @Test
     fun test_sendMessageReceipt_success() = runTest {
         val messageId = "messageId123"
@@ -615,7 +666,7 @@ class ChatServiceImplTest {
         // Add message in internal transcript
         val transcriptItem = Message(id = "1", timeStamp = "mockedTimestamp", participant = "user",
             contentType = "text/plain", text = "Hello")
-        (chatService as ChatServiceImpl).internalTranscript.add(0, transcriptItem)
+        chatService.internalTranscript.add(0, transcriptItem)
 
         // Execute reset
         chatService.reset()
@@ -623,7 +674,7 @@ class ChatServiceImplTest {
         // Validate that websocket disconnected, tokens are reset and internal transcript is deleted
         verify(webSocketManager).disconnect("Resetting ChatService")
         verify(connectionDetailsProvider).reset()
-        assertEquals(0, (chatService as ChatServiceImpl).internalTranscript.size)
+        assertEquals(0, chatService.internalTranscript.size)
     }
 
     private fun createMockConnectionDetails(token : String): ConnectionDetails {

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -547,9 +547,9 @@ class ChatServiceImplTest {
         `when`(awsClient.getTranscript(anyOrNull())).thenReturn(Result.success(mockGetTranscriptResult))
 
         // Add items to the internal transcript and emit reconnection event.
-        // This scenario should call getTranscript twice since nextToken is defined in the first call.
+        // This scenario should call getTranscript once since the empty transcript response.
         `when`(mockGetTranscriptResult.transcript).thenReturn(listOf())
-        `when`(mockGetTranscriptResult.nextToken).thenReturn("nextToken1").thenReturn("")
+        `when`(mockGetTranscriptResult.nextToken).thenReturn("nextToken1")
 
         val transcriptItem1 = Message(id = "1", timeStamp = "2024-01-01T00:00:00Z", participant = "user", contentType = "text/plain", text = "Hello")
         val transcriptItem2 = Message(id = "2", timeStamp = "2025-01-01T00:01:00Z", participant = "agent", contentType = "text/plain", text = "Hi")
@@ -558,7 +558,7 @@ class ChatServiceImplTest {
         val chatEvent = ChatEvent.ConnectionReEstablished
         eventSharedFlow.emit(chatEvent)
         advanceUntilIdle()
-        verify(awsClient, times(2)).getTranscript(anyOrNull())
+        verify(awsClient, times(1)).getTranscript(anyOrNull())
     }
 
     @Test

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.9
+sdkVersion=1.0.10
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR fixes an unexpected getTranscript loop regarding the re-connection flow. The issue stems from an unexpected behavior where calling getTranscript in the forward direction will always return the last item and a nextToken even if there are no more messages.

This PR fixes this issue by changing the conditional to add another check to see whether the last returned message is already within the internal transcript. If it is, we already know that we have fetched all available messages.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

