### PR TITLE
 Updating transcriptListPublisher to pass back previousTranscriptNextToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ From here, you are now ready to interact with the chat via the `ChatSession` obj
 The Amazon Connect Chat SDK for Android provides two methods to receive messages.
 
 1. Use [ChatSession.onTranscriptUpdated](#chatsessionontranscriptupdated)
-  * This event will pass back the entire transcript every time the transcript is updated. This will return the transcript via a List of [TranscriptItem](#transcriptitem)
+  * This event will pass back the entire transcript every time the transcript is updated. This will return the transcript inside the [TranscriptData](#transcriptdata) object.
 
 2. Use [ChatSession.onMessageReceived](#chatsessiononmessagereceived)
   * This event will pass back each message that is received by the WebSocket.  The event handler will be passed a single [TranscriptItem](#transcriptitem).
@@ -420,10 +420,10 @@ var onMessageReceived: ((TranscriptItem) -> Unit)?
 --------------------
 
 #### `ChatSession.onTranscriptUpdated`
-Callback for when the transcript is updated. See [TranscriptItem](#transcriptitem)
+Callback for when the transcript is updated. See [TranscriptData](#transcriptdata)
 
 ```
-var onTranscriptUpdated: ((List<TranscriptItem>) -> Unit)?
+var onTranscriptUpdated: ((TranscriptData) -> Unit)?
 ```
 
 --------------------
@@ -645,6 +645,23 @@ open class TranscriptItem(
 * `serializedContent`
   * The raw JSON format of the received WebSocket message
   * Type: Map of `String?`
+
+--------
+### TranscriptData
+This is the object that is passed back to the registered [ChatSession.onTranscriptUpdated](#chatsessionontranscriptupdated) event handler
+
+```
+data class TranscriptData(
+    val transcriptList: List<TranscriptItem>,
+    val previousTranscriptNextToken: String?
+)
+```
+* `transcriptList`
+  * The current in-memory transcript list.
+  * Type: Array of `TranscriptItem` (See [TranscriptItem](#transcriptitem))
+* `previousTranscriptNextToken`
+  * This is a next token that is used as a `getTranscript` argument to retrieve older messages.  This will be `null` if there are no more available messages to fetch from the top of the currently loaded transcript.
+  * Type: `String`
 
 --------
 ### Message (extends [TranscriptItem](#transcriptitem))

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -11,6 +11,7 @@ import com.amazon.connect.chat.sdk.model.GlobalConfig
 import com.amazon.connect.chat.sdk.model.Message
 import com.amazon.connect.chat.sdk.model.MessageReceiptType
 import com.amazon.connect.chat.sdk.model.MessageStatus
+import com.amazon.connect.chat.sdk.model.TranscriptData
 import com.amazon.connect.chat.sdk.model.TranscriptItem
 import com.amazon.connect.chat.sdk.model.TranscriptResponse
 import com.amazon.connect.chat.sdk.provider.ConnectionDetailsProvider
@@ -148,7 +149,7 @@ interface ChatSession {
     var onConnectionBroken: (() -> Unit)?
     var onDeepHeartBeatFailure: (() -> Unit)?
     var onMessageReceived: ((TranscriptItem) -> Unit)?
-    var onTranscriptUpdated: ((List<TranscriptItem>) -> Unit)?
+    var onTranscriptUpdated: ((TranscriptData) -> Unit)?
     var onChatEnded: (() -> Unit)?
     var isChatSessionActive: Boolean
 }
@@ -161,7 +162,7 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     override var onConnectionBroken: (() -> Unit)? = null
     override var onDeepHeartBeatFailure: (() -> Unit)? = null
     override var onMessageReceived: ((TranscriptItem) -> Unit)? = null
-    override var onTranscriptUpdated: ((List<TranscriptItem>) -> Unit)? = null
+    override var onTranscriptUpdated: ((TranscriptData) -> Unit)? = null
     override var onChatEnded: (() -> Unit)? = null
     override var onChatSessionStateChanged: ((Boolean) -> Unit)? = null
     override var isChatSessionActive: Boolean = false
@@ -205,11 +206,11 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
         }
 
         transcriptListCollectionJob = coroutineScope.launch {
-            chatService.transcriptListPublisher.collect { transcriptList ->
-                if (transcriptList.isNotEmpty()) {
+            chatService.transcriptListPublisher.collect { transcriptData ->
+                if (transcriptData.transcriptList.isNotEmpty()) {
                     // Make sure it runs on main thread
                     coroutineScope.launch {
-                        onTranscriptUpdated?.invoke(transcriptList)
+                        onTranscriptUpdated?.invoke(transcriptData)
                     }
                 }
             }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/TranscriptItem.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/TranscriptItem.kt
@@ -44,3 +44,8 @@ open class TranscriptItem(
     }
 }
 
+data class TranscriptData(
+    val transcriptList: List<TranscriptItem>,
+    val previousTranscriptNextToken: String?
+)
+

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -10,7 +10,6 @@ import com.amazon.connect.chat.sdk.model.ContentType
 import com.amazon.connect.chat.sdk.model.GlobalConfig
 import com.amazon.connect.chat.sdk.model.Message
 import com.amazon.connect.chat.sdk.model.MessageReceiptType
-import com.amazon.connect.chat.sdk.model.TranscriptData
 import com.amazon.connect.chat.sdk.model.TranscriptItem
 import com.amazon.connect.chat.sdk.model.TranscriptResponse
 import com.amazon.connect.chat.sdk.network.AWSClient

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -52,22 +52,10 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.Dispatchers
-<<<<<<< HEAD
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.setMain
-import org.mockito.kotlin.any
-=======
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.setMain
-import org.mockito.Mockito.spy
-import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
->>>>>>> 1d017c2 (Implementing previousTranscriptNextToken)
 import java.util.UUID
 import java.net.URL
 

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=1.0.10
+sdkVersion=2.0.0
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*


This PR updates the `transcriptListPublisher` logic.
- Returns `TranscriptData` object which contains the original `transcriptList` property as well as a `previousTranscriptNextToken` string property.
    - `previousTranscriptNextToken` represents the `nextToken` that will fetch the next batch of older transcripts
- Adding debounce to `transcriptListPublisher` updates to reduce the number of handler calls.  Original behavior would call the update event for each message in a `getTranscript` result (i.e. if `getTranscript` returned 100 messages, it would trigger 100 times).

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

YES

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

