### PR TITLE
Add persistentId field in Message for common attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,11 +630,12 @@ open class TranscriptItem(
     id: String = "",
     timeStamp: String,
     override var contentType: String,
-    override var serializedContent: String? = null
+    override var serializedContent: String? = null,
+    persistentId: String = ""
 )
 ```
 * `id`
-  * Id for the message. Unique to each message in the transcript.
+  * Id for the message. Unique to each message in the transcript. Id can be used only for the ACPS APIs requests.
   * Type: `String`
 * `timeStamp`
   * Time when the message or event was sent. Formatted in ISO 8601 (e.g. `yyyy-MM-ddThh:mm:ss.SSSZ` or ` 2019-11-08T02:41:28.172Z`)
@@ -645,6 +646,9 @@ open class TranscriptItem(
 * `serializedContent`
   * The raw JSON format of the received WebSocket message
   * Type: Map of `String?`
+* `persistentId`
+  * Id for the message, Unique to each message throughout chat session. This can be used only for tracking purposes by the client.
+  * Type: `String`
 
 --------
 ### TranscriptData

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/Message.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/Message.kt
@@ -31,7 +31,8 @@ data class Message(
     override var displayName: String? = null,
     override var messageDirection: MessageDirection? = null,
     var attachmentId: String? = null,
-    override var metadata: MessageMetadataProtocol? = null
+    override var metadata: MessageMetadataProtocol? = null,
+    override var persistentId: String? = null,
 ) : TranscriptItem(id, timeStamp, contentType, serializedContent), MessageProtocol {
 
     val content: MessageContent?

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/TranscriptItem.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/TranscriptItem.kt
@@ -8,19 +8,24 @@ interface TranscriptItemProtocol {
     val timeStamp: String
     var contentType: String
     var serializedContent: String?
+    var persistentId: String?
 }
 
 open class TranscriptItem(
     override var id: String,
     override var timeStamp: String,
     override var contentType: String,
-    override var serializedContent: String? = null
+    override var serializedContent: String? = null,
+    override var persistentId: String? = null
 ) : TranscriptItemProtocol {
 
     internal fun updateId(newId: String) {
         this.id = newId
     }
 
+    internal fun updatePersistentId() {
+        this.persistentId = this.id
+    }
     internal fun updateTimeStamp(newTimeStamp: String) {
         this.timeStamp = newTimeStamp
     }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -395,6 +395,7 @@ class ChatServiceImpl @Inject constructor(
                 // already have that item in our internalTranscript, so we will just apply existing
                 // metadata to new item.
                 if (existingItem is Message && item is Message) {
+                    item.persistentId = existingItem.persistentId
                     if (existingItem.metadata != null && item.metadata == null) {
                         item.metadata = existingItem.metadata
                     }
@@ -432,6 +433,7 @@ class ChatServiceImpl @Inject constructor(
             if (transcriptDict[newId] != null) {
                 transcriptDict.remove(oldId)
                 internalTranscript.removeAll { it.id == oldId }
+                transcriptDict[newId]?.persistentId = oldId
                 // Send out updated transcript
                 coroutineScope.launch {
                     _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
@@ -440,6 +442,7 @@ class ChatServiceImpl @Inject constructor(
                 // Update the placeholder message's ID to the new ID
                 (placeholderMessage as TranscriptItem).updateId(newId)
                 placeholderMessage.metadata?.status = MessageStatus.Sent
+                placeholderMessage.persistentId = oldId
                 transcriptDict.remove(oldId)
                 transcriptDict[newId] = placeholderMessage
             }
@@ -457,6 +460,7 @@ class ChatServiceImpl @Inject constructor(
         tempMessage.text = message.text
         tempMessage.contentType = message.contentType
         tempMessage.attachmentId = message.attachmentId
+        tempMessage.updatePersistentId()
         currentDict.remove(tempMessage.id)
         currentDict[message.id] = tempMessage
         handleTranscriptItemUpdate(tempMessage)


### PR DESCRIPTION
**Issue Number:** #55


### Description:
*What are the changes? Why are we making them?*
This change introduces a new field called persistentId to the Message object. The persistentId can be used by customers to consistently track messages, as it will remain the same during both message initiation and creation.
---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]
YES

*Does this change introduce any new dependency?* [YES/NO]
NO

---

### Testing:
*Is the code unit tested?*
Yes this code i s tested locally
*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*
No

*List manual testing steps:*
 - Add Steps below: 
- Initiated message creation with persistentId set to the same value as message Id.
- Verified that transcript messages retain the same persistentId during message creation

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

