### PR TITLE
Allow logger to be enabled/disabled

### DIFF
--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/utils/CustomLogger.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/utils/CustomLogger.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.FileNotFoundException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -25,8 +24,16 @@ class CustomLogger : ChatSDKLogger {
     private val currentTimeMillis = System.currentTimeMillis()
     private val loggerCreationDateAndTime = CommonUtils.formatDate(currentTimeMillis, false)
 
+    private var loggingEnabled: Boolean = true
+
+    //Custom logging logic
+    override fun setLoggingEnabled(enabled: Boolean) {
+        this.loggingEnabled = enabled
+    }
+
     override fun logVerbose(message: () -> String) {
         // Custom logging logic
+        if (!loggingEnabled) return
         val logMessage = "VERBOSE: ${message()}"
         println(logMessage)
         coroutineScope.launch {
@@ -36,6 +43,7 @@ class CustomLogger : ChatSDKLogger {
 
     override fun logInfo(message: () -> String) {
         // Custom logging logic
+        if (!loggingEnabled) return
         val logMessage = "INFO: ${message()}"
         println(logMessage)
         coroutineScope.launch {
@@ -45,16 +53,17 @@ class CustomLogger : ChatSDKLogger {
 
     override fun logDebug(message: () -> String) {
         // Custom logging logic
+        if (!loggingEnabled) return
         val logMessage = "DEBUG: ${message()}"
         println(logMessage)
         coroutineScope.launch {
             writeToAppTempFile(logMessage)
         }
-
     }
 
     override fun logWarn(message: () -> String) {
         // Custom logging logic
+        if (!loggingEnabled) return
         val logMessage = "WARN: ${message()}"
         println(logMessage)
         coroutineScope.launch {
@@ -64,6 +73,7 @@ class CustomLogger : ChatSDKLogger {
 
     override fun logError(message: () -> String) {
         // Custom logging logic
+        if (!loggingEnabled) return
         val logMessage = "ERROR: ${message()}"
         println(logMessage)
         coroutineScope.launch {

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/TranscriptItemUtils.kt
@@ -11,6 +11,7 @@ import com.amazon.connect.chat.sdk.model.MessageDirection
 import com.amazon.connect.chat.sdk.model.MessageMetadata
 import com.amazon.connect.chat.sdk.model.MessageStatus
 import com.amazonaws.services.connectparticipant.model.Item
+import com.amazon.connect.chat.sdk.utils.logger.SDKLogger
 import org.json.JSONObject
 import java.util.UUID
 
@@ -115,7 +116,7 @@ object TranscriptItemUtils {
 
             json.optString("content")
         } catch (e: Exception) {
-            Log.e("TranscriptItemUtils", "Failed to process transcript item: ${e.message}")
+            SDKLogger.logger.logError{"TranscriptItemUtils: Failed to process transcript item: ${e.message}"}
             null
         }
     }


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

