### PR TITLE
change kapt to ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.serialization)
     id("com.spotify.ruler")
-    id("kotlin-kapt") // Add this for kapt
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -94,9 +94,9 @@ dependencies {
     //Hilt
     implementation(libs.hiltAndroid)
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
-    kapt(libs.hiltCompiler)
+    ksp(libs.hiltCompiler)
     implementation("androidx.navigation:navigation-compose:2.7.7")
-    kapt(libs.hiltAndroidCompiler)
+    ksp(libs.hiltAndroidCompiler)
 
     // AWS
     implementation(libs.awsSdkCore)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,4 +14,5 @@ plugins {
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.hilt) apply false
+    id("com.google.devtools.ksp") version "1.9.20-1.0.14" apply false
 }

--- a/chat-sdk/build.gradle.kts
+++ b/chat-sdk/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.serialization)
     id("com.spotify.ruler")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -93,8 +93,8 @@ dependencies {
     //Hilt
     compileOnly(libs.hiltAndroid)
     compileOnly(libs.lifecycleProcess)
-    kapt(libs.hiltCompiler)
-    kapt(libs.hiltAndroidCompiler)
+    ksp(libs.hiltCompiler)
+    ksp(libs.hiltAndroidCompiler)
 
     // AWS
     api(libs.awsSdkCore)


### PR DESCRIPTION

### Description:
Project does not compile in latest android studio version due to kaptCompiler issue. Ksp is the recommended solution by google https://developer.android.com/build/migrate-to-ksp

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?* 

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
Basic sanity checks - start chat , send message, end chat

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

