### PR TITLE
update error handling logic for websocket reconnect

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -653,7 +653,7 @@ class ChatServiceImpl @Inject constructor(
                 setupWebSocket(connectionDetails.websocketUrl, true)
             } else {
                 val error = result.exceptionOrNull()
-                if (error?.message == "Access denied") {
+                if (error?.message?.contains("403") == true) {
                     // Handle chat ended scenario
                     val endedEvent = TranscriptItemUtils.createDummyEndedEvent()
                     updateTranscriptDict(endedEvent)


### PR DESCRIPTION
**Issue Number:**

### Description:
Update error handling to check for status code. Previously, this check was false when it was expected to be true

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [No]

*Does this change introduce any new dependency?* [NO]

---

### Testing:
*Is the code unit tested?* Yes

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?* yes

*List manual testing steps:*
 - Add Steps below: 

Connect physical device. Start chat -> accept from agent -> turn off wifi on physical device -> disconnect on agent side -> reconnect on physical device. See the chat ended event appear
