### PR TITLE
Fix/lifecycle observer threading issue

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -3,6 +3,8 @@
 
 package com.amazon.connect.chat.sdk.network
 
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -145,8 +147,14 @@ class WebSocketManagerImpl @Inject constructor(
         }
 
         // Ensure lifecycle observer registration happens on main thread
-        android.os.Handler(android.os.Looper.getMainLooper()).post {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            // Already on main thread, no need to post
             ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleObserver)
+        } else {
+            // Not on main thread, post to main thread
+            Handler(Looper.getMainLooper()).post {
+                ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleObserver)
+            }
         }
     }
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -144,7 +144,10 @@ class WebSocketManagerImpl @Inject constructor(
             }
         }
 
-        ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleObserver)
+        // Ensure lifecycle observer registration happens on main thread
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleObserver)
+        }
     }
 
     // --- Initialization and Connection Management ---

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -613,8 +613,10 @@ class ChatServiceImpl @Inject constructor(
     }
 
     private fun registerNotificationListeners() {
-        // Observe lifecycle events
-        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+        // Observe lifecycle events - ensure this happens on main thread
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(this@ChatServiceImpl)
+        }
 
         coroutineScope.launch {
             webSocketManager.requestNewWsUrlFlow.collect {

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -5,6 +5,8 @@ package com.amazon.connect.chat.sdk.repository
 
 import android.content.Context
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -614,8 +616,14 @@ class ChatServiceImpl @Inject constructor(
 
     private fun registerNotificationListeners() {
         // Observe lifecycle events - ensure this happens on main thread
-        android.os.Handler(android.os.Looper.getMainLooper()).post {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            // Already on main thread, no need to post
             ProcessLifecycleOwner.get().lifecycle.addObserver(this@ChatServiceImpl)
+        } else {
+            // Not on main thread, post to main thread
+            Handler(Looper.getMainLooper()).post {
+                ProcessLifecycleOwner.get().lifecycle.addObserver(this@ChatServiceImpl)
+            }
         }
 
         coroutineScope.launch {


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

