### PR TITLE
feat: implement transcript optimization for Android SDK

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -47,7 +47,7 @@ object EventTypes {
 
 interface WebSocketManager {
     val eventPublisher: SharedFlow<ChatEvent>
-    val transcriptPublisher: SharedFlow<TranscriptItem>
+    val transcriptPublisher: SharedFlow<Pair<TranscriptItem, Boolean>>
     val requestNewWsUrlFlow: MutableSharedFlow<Unit>
     var isReconnecting: MutableStateFlow<Boolean>
     suspend fun connect(wsUrl: String, isReconnectFlow: Boolean = false)
@@ -96,11 +96,11 @@ class WebSocketManagerImpl @Inject constructor(
     )
     override val eventPublisher: SharedFlow<ChatEvent> get() = _eventPublisher
 
-    private val _transcriptPublisher = MutableSharedFlow<TranscriptItem>(
+    private val _transcriptPublisher = MutableSharedFlow<Pair<TranscriptItem, Boolean>>(
         replay = 0,
         extraBufferCapacity = 10
     )
-    override val transcriptPublisher: SharedFlow<TranscriptItem> get() = _transcriptPublisher
+    override val transcriptPublisher: SharedFlow<Pair<TranscriptItem, Boolean>> get() = _transcriptPublisher
     override val requestNewWsUrlFlow = MutableSharedFlow<Unit>()
 
     init {
@@ -272,7 +272,7 @@ class WebSocketManagerImpl @Inject constructor(
         content?.let {
             val transcriptItem = parseTranscriptItemFromJson(it)
             if (transcriptItem != null) {
-                this._transcriptPublisher.emit(transcriptItem)
+                this._transcriptPublisher.emit(Pair(transcriptItem, true))
             } else {
                 SDKLogger.logger.logInfo{"WebSocket: Received unrecognized or unsupported content."}
             }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -162,11 +162,6 @@ interface ChatService {
     val transcriptPublisher: SharedFlow<TranscriptItem>
     val transcriptListPublisher: SharedFlow<TranscriptData>
     val chatSessionStatePublisher: SharedFlow<Boolean>
-    
-    /**
-     * Triggers transcript list update manually
-     */
-    fun triggerTranscriptListUpdate()
 }
 
 class ChatServiceImpl @Inject constructor(
@@ -299,7 +294,7 @@ class ChatServiceImpl @Inject constructor(
         }
     }
 
-    override fun triggerTranscriptListUpdate() {
+    private fun triggerTranscriptListUpdate() {
         coroutineScope.launch {
             _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
         }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
@@ -163,6 +162,11 @@ interface ChatService {
     val transcriptPublisher: SharedFlow<TranscriptItem>
     val transcriptListPublisher: SharedFlow<TranscriptData>
     val chatSessionStatePublisher: SharedFlow<Boolean>
+    
+    /**
+     * Triggers transcript list update manually
+     */
+    fun triggerTranscriptListUpdate()
 }
 
 class ChatServiceImpl @Inject constructor(
@@ -202,8 +206,6 @@ class ChatServiceImpl @Inject constructor(
     private var typingIndicatorTimer: Timer? = null
     private var throttleTypingEventTimer: Timer? = null
     private var throttleTypingEvent: Boolean = false
-
-    private var debounceTranscriptListPublisherEvent: Job? = null
 
     // Dictionary to map attachment IDs to temporary message IDs
     private val attachmentIdToTempMessageId = mutableMapOf<String, String>()
@@ -285,8 +287,8 @@ class ChatServiceImpl @Inject constructor(
         }
 
         transcriptCollectionJob = coroutineScope.launch {
-            webSocketManager.transcriptPublisher.collect { transcriptItem ->
-                updateTranscriptDict(transcriptItem)
+            webSocketManager.transcriptPublisher.collect { (transcriptItem, shouldTriggerTranscriptListUpdate) ->
+                updateTranscriptDict(transcriptItem, shouldTriggerTranscriptListUpdate)
             }
         }
 
@@ -297,7 +299,13 @@ class ChatServiceImpl @Inject constructor(
         }
     }
 
-    private fun updateTranscriptDict(item: TranscriptItem) {
+    override fun triggerTranscriptListUpdate() {
+        coroutineScope.launch {
+            _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+        }
+    }
+
+    private fun updateTranscriptDict(item: TranscriptItem, shouldTriggerTranscriptListUpdate: Boolean = true) {
         when (item) {
             is MessageMetadata -> {
                 // Associate metadata with message based on its ID
@@ -333,7 +341,7 @@ class ChatServiceImpl @Inject constructor(
         }
 
         transcriptDict[item.id]?.let {
-            handleTranscriptItemUpdate(it)
+            handleTranscriptItemUpdate(it, shouldTriggerTranscriptListUpdate)
         }
 
     }
@@ -380,7 +388,7 @@ class ChatServiceImpl @Inject constructor(
     }
 
 
-    private fun handleTranscriptItemUpdate(item: TranscriptItem) {
+    private fun handleTranscriptItemUpdate(item: TranscriptItem, shouldTriggerTranscriptListUpdate: Boolean = true) {
         // Send out the individual transcript item to subscribers
         coroutineScope.launch {
             _transcriptPublisher.emit(item)
@@ -414,9 +422,7 @@ class ChatServiceImpl @Inject constructor(
                 }
             }
 
-            debounceTranscriptListPublisherEvent?.cancel()
-            debounceTranscriptListPublisherEvent = coroutineScope.launch {
-                delay(300)
+            if (shouldTriggerTranscriptListUpdate) {
                 _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
             }
         }
@@ -824,14 +830,17 @@ class ChatServiceImpl @Inject constructor(
                 }
             }
 
-            // Format and process transcript items
+            // Process transcript items without triggering individual updates
             val formattedItems = transcriptItems.mapNotNull { transcriptItem ->
                 TranscriptItemUtils.serializeTranscriptItem(transcriptItem)?.let { serializedItem ->
                     webSocketManager.parseTranscriptItemFromJson(serializedItem)?.also { parsedItem ->
-                        updateTranscriptDict(parsedItem)
+                        updateTranscriptDict(parsedItem, shouldTriggerTranscriptListUpdate = false)
                     }
                 }
             }
+            
+            // Trigger single transcript list update after all items are processed
+            triggerTranscriptListUpdate()
 
             SDKLogger.logger.logDebug { "Transcript fetched successfully" }
             SDKLogger.logger.logDebug { "Transcript Items: $formattedItems" }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -294,10 +294,8 @@ class ChatServiceImpl @Inject constructor(
         }
     }
 
-    private fun triggerTranscriptListUpdate() {
-        coroutineScope.launch {
-            _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
-        }
+    private suspend fun triggerTranscriptListUpdate() {
+        _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
     }
 
     private fun updateTranscriptDict(item: TranscriptItem, shouldTriggerTranscriptListUpdate: Boolean = true) {
@@ -418,7 +416,7 @@ class ChatServiceImpl @Inject constructor(
             }
 
             if (shouldTriggerTranscriptListUpdate) {
-                _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+                triggerTranscriptListUpdate()
             }
         }
     }

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -721,6 +721,7 @@ class ChatServiceImplTest {
 
     @Test
     fun test_transcriptListPublisher_emitsTranscriptList() = runTest {
+        var assertCalled = false
         var emissionCount = 0
         val chatDetails = ChatDetails(participantToken = "token")
         chatService.createChatSession(chatDetails)
@@ -744,6 +745,7 @@ class ChatServiceImplTest {
                         assertEquals(2, transcriptData.transcriptList.size)
                         assertEquals(transcriptItem1, transcriptData.transcriptList[0])
                         assertEquals(transcriptItem2, transcriptData.transcriptList[1])
+                        assertCalled = true
                     }
                 }
             }
@@ -757,8 +759,11 @@ class ChatServiceImplTest {
         // Cancel the job after testing to ensure the coroutine completes
         job.cancel()
 
-        // Verify we got exactly 2 emissions
+        // Verify we got exactly 2 emissions and the final assertion was called
         assertEquals(2, emissionCount)
+        if (!assertCalled) {
+            fail("chatService.transcriptListPublisher.onEach was not triggered for final emission")
+        }
     }
 
     @Test

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/ChatServiceImplTest.kt
@@ -85,7 +85,7 @@ class ChatServiceImplTest {
 
     private lateinit var chatService: ChatServiceImpl
     private lateinit var eventSharedFlow: MutableSharedFlow<ChatEvent>
-    private lateinit var transcriptSharedFlow: MutableSharedFlow<TranscriptItem>
+    private lateinit var transcriptSharedFlow: MutableSharedFlow<Pair<TranscriptItem, Boolean>>
     private lateinit var chatSessionStateFlow: MutableStateFlow<Boolean>
     private lateinit var newWsUrlFlow: MutableSharedFlow<Unit>
 
@@ -556,8 +556,8 @@ class ChatServiceImplTest {
         // Add items to the internal transcript
         val transcriptItem1 = Message(id = "1", timeStamp = "2024-01-01T00:00:00Z", participant = "user", contentType = "text/plain", text = "Hello")
         val transcriptItem2 = Message(id = "2", timeStamp = "2025-01-01T00:01:00Z", participant = "agent", contentType = "text/plain", text = "Hi")
-        transcriptSharedFlow.emit(transcriptItem1)
-        transcriptSharedFlow.emit(transcriptItem2)
+        transcriptSharedFlow.emit(Pair(transcriptItem1, true))
+        transcriptSharedFlow.emit(Pair(transcriptItem2, true))
         advanceUntilIdle()
 
         // Expect previousTranscriptNextToken to persist when items are added
@@ -709,7 +709,7 @@ class ChatServiceImplTest {
             .launchIn(this)
 
         // Emit the transcript item
-        transcriptSharedFlow.emit(transcriptItem)
+        transcriptSharedFlow.emit(Pair(transcriptItem, true))
         advanceUntilIdle()
         // Cancel the job after testing to ensure the coroutine completes
         job.cancel()
@@ -721,7 +721,7 @@ class ChatServiceImplTest {
 
     @Test
     fun test_transcriptListPublisher_emitsTranscriptList() = runTest {
-        var assertCalled = false
+        var emissionCount = 0
         val chatDetails = ChatDetails(participantToken = "token")
         chatService.createChatSession(chatDetails)
         advanceUntilIdle()
@@ -732,24 +732,33 @@ class ChatServiceImplTest {
         // Launch the flow collection within the test's coroutine scope
         val job = chatService.transcriptListPublisher
             .onEach { transcriptData ->
-                assertEquals(transcriptData.transcriptList.size, 2)
-                assertEquals(transcriptData.transcriptList[0], transcriptItem1)
-                assertEquals(transcriptData.transcriptList[1], transcriptItem2)
-                assertCalled = true
+                emissionCount++
+                when (emissionCount) {
+                    1 -> {
+                        // First emission should have 1 item
+                        assertEquals(1, transcriptData.transcriptList.size)
+                        assertEquals(transcriptItem1, transcriptData.transcriptList[0])
+                    }
+                    2 -> {
+                        // Second emission should have 2 items
+                        assertEquals(2, transcriptData.transcriptList.size)
+                        assertEquals(transcriptItem1, transcriptData.transcriptList[0])
+                        assertEquals(transcriptItem2, transcriptData.transcriptList[1])
+                    }
+                }
             }
             .launchIn(this)
 
-        // Emit the transcript list
-        transcriptSharedFlow.emit(transcriptItem1)
-        transcriptSharedFlow.emit(transcriptItem2)
+        // Emit the transcript items
+        transcriptSharedFlow.emit(Pair(transcriptItem1, true))
+        transcriptSharedFlow.emit(Pair(transcriptItem2, true))
         advanceUntilIdle()
 
         // Cancel the job after testing to ensure the coroutine completes
         job.cancel()
 
-        if (!assertCalled) {
-            fail("chatService.transcriptPublisher.onEach was not triggered")
-        }
+        // Verify we got exactly 2 emissions
+        assertEquals(2, emissionCount)
     }
 
     @Test


### PR DESCRIPTION


**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

- Remove debounce timer for immediate real-time updates
- Add flag-based control to suppress bulk loading updates
- Optimize getTranscript to trigger single transcript list update
- Update WebSocketManager to use Pair<TranscriptItem, Boolean> pattern
- Fix unit tests to handle new immediate update behavior

Reference related IOS PR https://github.com/amazon-connect/amazon-connect-chat-ios/commit/a4cf6deb6378ec7daa0dc20d0ec909c36194ab7a

Reduces bulk transcript loading from updates for each message to 1 single update while maintaining immediate responsiveness for real-time messages. Matches iOS SDK optimization pattern.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES]

*Does this change introduce any new dependency?* [YES]

---

### Testing:
*Is the code unit tested?* yes

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?* yes

*List manual testing steps:*
 - Add Steps below: 

Start the chat, type messages. Background and foreground, see the onTranscriptUpdated logs. Verify transcript is in right order and only emitted once

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

