### PR TITLE
Sending copy of transcript instead of reference for onTranscriptUpdated

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -297,7 +297,7 @@ class ChatServiceImpl @Inject constructor(
     }
 
     private suspend fun triggerTranscriptListUpdate() {
-        _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+        _transcriptListPublisher.emit(TranscriptData(internalTranscript.toList(), previousTranscriptNextToken))
     }
 
     private fun updateTranscriptDict(item: TranscriptItem, shouldTriggerTranscriptListUpdate: Boolean = true) {
@@ -358,7 +358,7 @@ class ChatServiceImpl @Inject constructor(
         // Send the updated transcript list to subscribers if items removed
         if (transcriptDict.size != initialCount) {
             coroutineScope.launch {
-                _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+                _transcriptListPublisher.emit(TranscriptData(internalTranscript.toList(), previousTranscriptNextToken))
             }
         }
     }
@@ -437,7 +437,7 @@ class ChatServiceImpl @Inject constructor(
                 transcriptDict[newId]?.persistentId = oldId
                 // Send out updated transcript
                 coroutineScope.launch {
-                    _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+                    _transcriptListPublisher.emit(TranscriptData(internalTranscript.toList(), previousTranscriptNextToken))
                 }
             } else {
                 // Update the placeholder message's ID to the new ID
@@ -570,7 +570,7 @@ class ChatServiceImpl @Inject constructor(
         transcriptDict.remove(messageId)
         // Send out updated transcript with old message removed
         coroutineScope.launch {
-            _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+            _transcriptListPublisher.emit(TranscriptData(internalTranscript.toList(), previousTranscriptNextToken))
         }
 
         // as the next step, attempt to resend the message based on its type
@@ -816,7 +816,7 @@ class ChatServiceImpl @Inject constructor(
             if ((request.scanDirection == ScanDirection.BACKWARD.toString()) && !(isStartPositionDefined && transcriptItems.isEmpty())) {
                 if (internalTranscript.isEmpty() || transcriptItems.isEmpty()) {
                     previousTranscriptNextToken = response.nextToken
-                    _transcriptListPublisher.emit(TranscriptData(internalTranscript, previousTranscriptNextToken))
+                    _transcriptListPublisher.emit(TranscriptData(internalTranscript.toList(), previousTranscriptNextToken))
                 } else {
                     val oldestInternalTranscriptItem = internalTranscript.first()
                     val oldestTranscriptItem: Item;

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/HeartbeatManagerTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/repository/HeartbeatManagerTest.kt
@@ -51,11 +51,13 @@ class HeartbeatManagerTest {
 
     @Test
     fun `test stopHeartbeat cancels timer`() = runTest {
+        // Set pendingResponse to true to simulate heartbeat being sent
         heartbeatManager.startHeartbeat()
+        setPrivateField(heartbeatManager, "pendingResponse", true)
 
         heartbeatManager.stopHeartbeat()
 
-        // PendingResponse should be false and timer should be null
+        // PendingResponse should be false after stopHeartbeat, regardless of previous state
         val pendingResponse = getPrivateField(heartbeatManager, "pendingResponse") as Boolean
         assert(!pendingResponse) { "Expected pendingResponse to be false after stopHeartbeat" }
 


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

Currently, we are sending a reference to the internal transcript object whenever we call `onTranscriptUpdated`.  This is unexpected and does not match the behavior in iOS. 

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

Sort of, but users would generally not expect the transcript to be a reference.

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

