### PR TITLE
Add Event Callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,10 +439,10 @@ var onTranscriptUpdated: ((TranscriptData) -> Unit)?
 --------------------
 
 #### `ChatSession.onChatEnded`
-Callback for when the chat ends.
+Callback for when the chat ends. See [Event](#event).
 
 ```
-var onChatEnded: (() -> Unit)?
+var onChatEnded: ((Event?) -> Unit)?
 ```
 
 --------------------
@@ -451,6 +451,97 @@ Callback for when the connection is re-established.
 
 ```
 var onConnectionReEstablished: (() -> Unit)?
+```
+--------------------
+#### `ChatSession.onDeepHeartBeatFailure`
+Callback for when the deep heartbeat fails.
+
+```
+var onDeepHeartBeatFailure: (() -> Unit)?
+```
+--------------------
+#### `ChatSession.onTyping`
+Callback for when a typing event is received. See [Event](#event).
+
+```
+var onTyping: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onMessageDelivered`
+Callback for when a message delivery receipt is received. See [Event](#event).
+
+```
+var onMessageDelivered: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onMessageRead`
+Callback for when a message read receipt is received. See [Event](#event).
+
+```
+var onMessageRead: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantActive`
+Callback for when a participant becomes active. See [Event](#event).
+
+```
+var onParticipantActive: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantInactive`
+Callback for when a participant becomes inactive. See [Event](#event).
+
+```
+var onParticipantInactive: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantIdle`
+Callback for when a participant becomes idle. See [Event](#event).
+
+```
+var onParticipantIdle: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantReturned`
+Callback for when a participant returns from idle/inactive state. See [Event](#event).
+
+```
+var onParticipantReturned: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantInvited`
+Callback for when a participant is invited to the chat. See [Event](#event).
+
+```
+var onParticipantInvited: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onAutoDisconnection`
+Callback for when an auto-disconnection occurs. See [Event](#event).
+
+```
+var onAutoDisconnection: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onChatRehydrated`
+Callback for when the chat is rehydrated after a reconnection. See [Event](#event).
+
+```
+var onChatRehydrated: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantJoined`
+Callback for when a participant joins the chat. See [Event](#event).
+
+```
+var onParticipantJoined: ((Event?) -> Unit)?
+```
+--------------------
+#### `ChatSession.onParticipantLeft`
+Callback for when a participant leaves the chat. See [Event](#event).
+
+```
+var onParticipantLeft: ((Event?) -> Unit)?
 ```
 --------------------
 

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
@@ -3,9 +3,9 @@ package com.amazon.connect.chat.androidchatexample
 import com.amazonaws.regions.Regions
 
 object Config {
-    val connectInstanceId: String = "9e330fe8-389b-4e51-b6b2-c249462d7e33"
-    val contactFlowId: String = "a1acd643-869d-45a0-b758-d380214580cd"
-    val startChatEndpoint: String = "https://kopg30tz0m.execute-api.us-west-2.amazonaws.com/Prod/"
+    val connectInstanceId: String = ""
+    val contactFlowId: String = ""
+    val startChatEndpoint: String = "https://<endpoint>.execute-api.<region>.amazonaws.com/Prod/"
     val region: Regions = Regions.US_WEST_2
     val agentName = "AGENT"
     val customerName = "CUSTOMER"

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/Config.kt
@@ -3,9 +3,9 @@ package com.amazon.connect.chat.androidchatexample
 import com.amazonaws.regions.Regions
 
 object Config {
-    val connectInstanceId: String = ""
-    val contactFlowId: String = ""
-    val startChatEndpoint: String = "https://<endpoint>.execute-api.<region>.amazonaws.com/Prod/"
+    val connectInstanceId: String = "9e330fe8-389b-4e51-b6b2-c249462d7e33"
+    val contactFlowId: String = "a1acd643-869d-45a0-b758-d380214580cd"
+    val startChatEndpoint: String = "https://kopg30tz0m.execute-api.us-west-2.amazonaws.com/Prod/"
     val region: Regions = Regions.US_WEST_2
     val agentName = "AGENT"
     val customerName = "CUSTOMER"

--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
@@ -134,8 +134,8 @@ class ChatViewModel @Inject constructor(
             }
         }
 
-        chatSession.onChatEnded = {
-           Log.d("ChatViewModel", "Chat ended.")
+        chatSession.onChatEnded = { event ->
+            Log.d("ChatViewModel", "Chat ended.")
             _isChatActive.value = false
         }
 
@@ -155,6 +155,54 @@ class ChatViewModel @Inject constructor(
 
         chatSession.onDeepHeartBeatFailure = {
             Log.d("ChatViewModel", "Deep heartbeat failure")
+        }
+
+        chatSession.onTyping = { event ->
+            Log.d("ChatViewModel", "onTyping: $event")
+        }
+
+        chatSession.onMessageDelivered = { event ->
+            Log.d("ChatViewModel", "onMessageDelivered: $event")
+        }
+
+        chatSession.onMessageRead = { event ->
+            Log.d("ChatViewModel", "onMessageRead: $event")
+        }
+
+        chatSession.onParticipantActive = { event ->
+            Log.d("ChatViewModel", "onParticipantActive: $event")
+        }
+
+        chatSession.onParticipantInactive = { event ->
+            Log.d("ChatViewModel", "onParticipantInactive: $event")
+        }
+
+        chatSession.onParticipantIdle = { event ->
+            Log.d("ChatViewModel", "onParticipantIdle: $event")
+        }
+
+        chatSession.onParticipantReturned = { event ->
+            Log.d("ChatViewModel", "onParticipantReturned: $event")
+        }
+
+        chatSession.onParticipantInvited = { event ->
+            Log.d("ChatViewModel", "onParticipantInvited: $event")
+        }
+
+        chatSession.onAutoDisconnection = { event ->
+            Log.d("ChatViewModel", "onAutoDisconnection: $event")
+        }
+
+        chatSession.onChatRehydrated = { event ->
+            Log.d("ChatViewModel", "onChatRehydrated: $event")
+        }
+
+        chatSession.onParticipantJoined = { event ->
+            Log.d("ChatViewModel", "onParticipantJoined: $event")
+        }
+
+        chatSession.onParticipantLeft = { event ->
+            Log.d("ChatViewModel", "onParticipantLeft: $event")
         }
     }
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -163,6 +163,8 @@ interface ChatSession {
     var onChatRehydrated: ((Event?) -> Unit)?
     var onParticipantJoined: ((Event?) -> Unit)?
     var onParticipantLeft: ((Event?) -> Unit)?
+    var onTransferSucceeded: ((Event?) -> Unit)?
+    var onTransferFailed: ((Event?) -> Unit)?
     var onChatEnded: ((Event?) -> Unit)?
     var isChatSessionActive: Boolean
 }
@@ -188,6 +190,8 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     override var onChatRehydrated: ((Event?) -> Unit)? = null
     override var onParticipantJoined: ((Event?) -> Unit)? = null
     override var onParticipantLeft: ((Event?) -> Unit)? = null
+    override var onTransferSucceeded: ((Event?) -> Unit)? = null
+    override var onTransferFailed: ((Event?) -> Unit)? = null
     override var onChatEnded: ((Event?) -> Unit)? = null
     override var onChatSessionStateChanged: ((Boolean) -> Unit)? = null
     override var isChatSessionActive: Boolean = false
@@ -252,6 +256,12 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
                     }
                     ChatEvent.ParticipantLeft -> {
                         onParticipantLeft?.invoke(eventWithData.eventObject)
+                    }
+                    ChatEvent.TransferSucceeded -> {
+                        onTransferSucceeded?.invoke(eventWithData.eventObject)
+                    }
+                    ChatEvent.TransferFailed -> {
+                        onTransferFailed?.invoke(eventWithData.eventObject)
                     }
                 }
             }
@@ -355,17 +365,13 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
 
     override suspend fun downloadAttachment(attachmentId: String, filename: String): Result<URL> {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.downloadAttachment(attachmentId, filename).getOrThrow()
-            }
+            chatService.downloadAttachment(attachmentId, filename)
         }
     }
 
     override suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL> {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                chatService.getAttachmentDownloadUrl(attachmentId).getOrThrow()
-            }
+            chatService.getAttachmentDownloadUrl(attachmentId)
         }
     }
 

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
@@ -70,6 +70,8 @@ enum class ChatEvent {
     ChatRehydrated,
     ParticipantJoined,
     ParticipantLeft,
+    TransferSucceeded,
+    TransferFailed,
 }
 
 data class ChatEventPayload(

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
@@ -58,4 +58,21 @@ enum class ChatEvent {
     ChatEnded,
     ConnectionBroken,
     DeepHeartBeatFailure,
+    Typing,
+    MessageDelivered,
+    MessageRead,
+    ParticipantActive,
+    ParticipantInactive,
+    ParticipantIdle,
+    ParticipantReturned,
+    ParticipantInvited,
+    AutoDisconnection,
+    ChatRehydrated,
+    ParticipantJoined,
+    ParticipantLeft,
 }
+
+data class ChatEventPayload(
+    val chatEvent: ChatEvent,
+    val eventObject: Event? = null
+)

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -441,7 +441,9 @@ class WebSocketManagerImpl @Inject constructor(
                 ContentType.CHAT_REHYDRATED,
                 ContentType.JOINED,
                 ContentType.LEFT,
-                ContentType.ENDED -> {
+                ContentType.ENDED,
+                ContentType.TRANSFER_SUCCEEDED,
+                ContentType.TRANSFER_FAILED -> {
                     Event(
                         participant = jsonObject.optString("ParticipantRole"),
                         text = jsonObject.optString("Content"),
@@ -469,6 +471,8 @@ class WebSocketManagerImpl @Inject constructor(
                 ContentType.JOINED -> ChatEvent.ParticipantJoined
                 ContentType.LEFT -> ChatEvent.ParticipantLeft
                 ContentType.ENDED -> ChatEvent.ChatEnded
+                ContentType.TRANSFER_SUCCEEDED -> ChatEvent.TransferSucceeded
+                ContentType.TRANSFER_FAILED -> ChatEvent.TransferFailed
                 else -> null
             }
             

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -745,20 +745,28 @@ class ChatServiceImpl @Inject constructor(
         return runCatching {
             val connectionDetails = connectionDetailsProvider.getConnectionDetails()
                 ?: throw Exception("No connection details available")
-            attachmentsManager.downloadAttachment(connectionDetails.connectionToken, attachmentId, fileName).getOrThrow()
-        }.onFailure { exception ->
-            SDKLogger.logger.logError { "Failed to download attachment for attachmentId $attachmentId. Error: ${exception.message}" }
-        }
+            attachmentsManager.downloadAttachment(connectionDetails.connectionToken, attachmentId, fileName)
+        }.fold(
+            onSuccess = { it },
+            onFailure = { exception ->
+                SDKLogger.logger.logError { "Failed to download attachment for attachmentId $attachmentId. Error: ${exception.message}" }
+                Result.failure(exception)
+            }
+        )
     }
 
     override suspend fun getAttachmentDownloadUrl(attachmentId: String): Result<URL> {
         return runCatching {
             val connectionDetails = connectionDetailsProvider.getConnectionDetails()
                 ?: throw Exception("No connection details available")
-            attachmentsManager.getAttachmentDownloadUrl(attachmentId, connectionDetails.connectionToken).getOrThrow()
-        }.onFailure { exception ->
-            SDKLogger.logger.logError { "Failed to retrieve attachment download URL for attachment $attachmentId. Error: ${exception.message}" }
-        }
+            attachmentsManager.getAttachmentDownloadUrl(attachmentId, connectionDetails.connectionToken)
+        }.fold(
+            onSuccess = { it },
+            onFailure = { exception ->
+                SDKLogger.logger.logError { "Failed to retrieve attachment download URL for attachment $attachmentId. Error: ${exception.message}" }
+                Result.failure(exception)
+            }
+        )
     }
 
     private suspend fun fetchReconnectedTranscript() {

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/Constants.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/utils/Constants.kt
@@ -39,6 +39,7 @@ object Constants {
         "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "heic" to "image/heic",
         "jpg" to "image/jpeg",
+        "jpeg" to "image/jpeg",
         "mov" to "video/quicktime",
         "mp4" to "video/mp4",
         "pdf" to "application/pdf",

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/utils/ConstantsTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/utils/ConstantsTest.kt
@@ -54,7 +54,7 @@ class ConstantsTest {
     @Test
     fun testAttachmentTypeMap() {
         // Test the size of the map
-        assertEquals(16, Constants.attachmentTypeMap.size)
+        assertEquals(17, Constants.attachmentTypeMap.size)
 
         // Test some key mappings
         assertEquals("text/csv", Constants.attachmentTypeMap["csv"])


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

Adding all relevant callback events that will pass back Event object.  See event list:
- onTyping
- onMessageDelivered
- onMessageRead
- onParticipantActive
- onParticipantInactive
- onParticipantIdle
- onParticipantReturned
- onParticipantInvited
- onAutoDisconnection
- onChatRehydrated
- onParticipantJoined
- onParticipantLeft
- onChatEnded

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

YES

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

