### PR TITLE
Fixing message ordering + Removing participant active/inactive events

### DIFF
--- a/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/amazon/connect/chat/androidchatexample/viewmodel/ChatViewModel.kt
@@ -169,14 +169,6 @@ class ChatViewModel @Inject constructor(
             Log.d("ChatViewModel", "onMessageRead: $event")
         }
 
-        chatSession.onParticipantActive = { event ->
-            Log.d("ChatViewModel", "onParticipantActive: $event")
-        }
-
-        chatSession.onParticipantInactive = { event ->
-            Log.d("ChatViewModel", "onParticipantInactive: $event")
-        }
-
         chatSession.onParticipantIdle = { event ->
             Log.d("ChatViewModel", "onParticipantIdle: $event")
         }

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/ChatSession.kt
@@ -154,8 +154,6 @@ interface ChatSession {
     var onTyping: ((Event?) -> Unit)?
     var onMessageDelivered: ((Event?) -> Unit)?
     var onMessageRead: ((Event?) -> Unit)?
-    var onParticipantActive: ((Event?) -> Unit)?
-    var onParticipantInactive: ((Event?) -> Unit)?
     var onParticipantIdle: ((Event?) -> Unit)?
     var onParticipantReturned: ((Event?) -> Unit)?
     var onParticipantInvited: ((Event?) -> Unit)?
@@ -181,8 +179,6 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
     override var onTyping: ((Event?) -> Unit)? = null
     override var onMessageDelivered: ((Event?) -> Unit)? = null
     override var onMessageRead: ((Event?) -> Unit)? = null
-    override var onParticipantActive: ((Event?) -> Unit)? = null
-    override var onParticipantInactive: ((Event?) -> Unit)? = null
     override var onParticipantIdle: ((Event?) -> Unit)? = null
     override var onParticipantReturned: ((Event?) -> Unit)? = null
     override var onParticipantInvited: ((Event?) -> Unit)? = null
@@ -229,12 +225,6 @@ class ChatSessionImpl @Inject constructor(private val chatService: ChatService) 
                     }
                     ChatEvent.MessageRead -> {
                         onMessageRead?.invoke(eventWithData.eventObject)
-                    }
-                    ChatEvent.ParticipantActive -> {
-                        onParticipantActive?.invoke(eventWithData.eventObject)
-                    }
-                    ChatEvent.ParticipantInactive -> {
-                        onParticipantInactive?.invoke(eventWithData.eventObject)
                     }
                     ChatEvent.ParticipantIdle -> {
                         onParticipantIdle?.invoke(eventWithData.eventObject)

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/model/ContentType.kt
@@ -61,8 +61,6 @@ enum class ChatEvent {
     Typing,
     MessageDelivered,
     MessageRead,
-    ParticipantActive,
-    ParticipantInactive,
     ParticipantIdle,
     ParticipantReturned,
     ParticipantInvited,

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -432,8 +432,6 @@ class WebSocketManagerImpl @Inject constructor(
             // Create Event object for callbacks that require it (excluding MESSAGE_DELIVERED and MESSAGE_READ)
             val eventObject = when (type) {
                 ContentType.TYPING,
-                ContentType.PARTICIPANT_ACTIVE,
-                ContentType.PARTICIPANT_INACTIVE,
                 ContentType.PARTICIPANT_IDLE,
                 ContentType.PARTICIPANT_RETURNED,
                 ContentType.PARTICIPANT_INVITED,
@@ -461,8 +459,6 @@ class WebSocketManagerImpl @Inject constructor(
             // Map ContentType to ChatEvent and emit through existing eventPublisher (excluding MESSAGE_DELIVERED and MESSAGE_READ)
             val chatEvent = when (type) {
                 ContentType.TYPING -> ChatEvent.Typing
-                ContentType.PARTICIPANT_ACTIVE -> ChatEvent.ParticipantActive
-                ContentType.PARTICIPANT_INACTIVE -> ChatEvent.ParticipantInactive
                 ContentType.PARTICIPANT_IDLE -> ChatEvent.ParticipantIdle
                 ContentType.PARTICIPANT_RETURNED -> ChatEvent.ParticipantReturned
                 ContentType.PARTICIPANT_INVITED -> ChatEvent.ParticipantInvited

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/ChatSessionImplTest.kt
@@ -280,8 +280,6 @@ class ChatSessionImplTest {
             "onTyping" to { callback: (Event?) -> Unit -> chatSession.onTyping = callback },
             "onMessageDelivered" to { callback: (Event?) -> Unit -> chatSession.onMessageDelivered = callback },
             "onMessageRead" to { callback: (Event?) -> Unit -> chatSession.onMessageRead = callback },
-            "onParticipantActive" to { callback: (Event?) -> Unit -> chatSession.onParticipantActive = callback },
-            "onParticipantInactive" to { callback: (Event?) -> Unit -> chatSession.onParticipantInactive = callback },
             "onParticipantIdle" to { callback: (Event?) -> Unit -> chatSession.onParticipantIdle = callback },
             "onParticipantReturned" to { callback: (Event?) -> Unit -> chatSession.onParticipantReturned = callback },
             "onParticipantInvited" to { callback: (Event?) -> Unit -> chatSession.onParticipantInvited = callback },
@@ -307,8 +305,6 @@ class ChatSessionImplTest {
                 "onTyping" -> chatSession.onTyping?.invoke(testEvent)
                 "onMessageDelivered" -> chatSession.onMessageDelivered?.invoke(testEvent)
                 "onMessageRead" -> chatSession.onMessageRead?.invoke(testEvent)
-                "onParticipantActive" -> chatSession.onParticipantActive?.invoke(testEvent)
-                "onParticipantInactive" -> chatSession.onParticipantInactive?.invoke(testEvent)
                 "onParticipantIdle" -> chatSession.onParticipantIdle?.invoke(testEvent)
                 "onParticipantReturned" -> chatSession.onParticipantReturned?.invoke(testEvent)
                 "onParticipantInvited" -> chatSession.onParticipantInvited?.invoke(testEvent)


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR updates the following:
- Fixing an issue with chat message ordering due to async processing of transcript items.  Updated logic so that items are processed sequentially.
- Removing Participant Active and Participant Inactive events from callbacks.  This is not exposed in ChatJS and we want to ensure consistency

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

