### PR TITLE
Version 2.0.4 Bump + Misc Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,20 +481,6 @@ Callback for when a message read receipt is received. See [Event](#event).
 var onMessageRead: ((Event?) -> Unit)?
 ```
 --------------------
-#### `ChatSession.onParticipantActive`
-Callback for when a participant becomes active. See [Event](#event).
-
-```
-var onParticipantActive: ((Event?) -> Unit)?
-```
---------------------
-#### `ChatSession.onParticipantInactive`
-Callback for when a participant becomes inactive. See [Event](#event).
-
-```
-var onParticipantInactive: ((Event?) -> Unit)?
-```
---------------------
 #### `ChatSession.onParticipantIdle`
 Callback for when a participant becomes idle. See [Event](#event).
 

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/network/AttachmentsManagerTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/network/AttachmentsManagerTest.kt
@@ -214,7 +214,14 @@ class AttachmentsManagerTest {
             .`when`(awsClient)
             .getAttachment(mockConnectionToken, mockAttachmentId)
 
+        // Stub downloadFile to avoid actual file I/O and return a successful result
+        doReturn(Result.success(URL(mockUrl)))
+            .`when`(attachmentsManager)
+            .downloadFile(URL(mockUrl), mockFilename)
+
+        // Await the completion of downloadAttachment
         attachmentsManager.downloadAttachment(mockConnectionToken, mockAttachmentId, mockFilename)
+        
         verify(awsClient).getAttachment(mockConnectionToken, mockAttachmentId)
         verify(attachmentsManager).getAttachmentDownloadUrl(mockConnectionToken, mockAttachmentId)
         verify(attachmentsManager).downloadFile(URL(mockUrl), mockFilename)

--- a/chat-sdk/version.properties
+++ b/chat-sdk/version.properties
@@ -1,3 +1,3 @@
-sdkVersion=2.0.3
+sdkVersion=2.0.4
 groupId=software.aws.connect
 artifactId=amazon-connect-chat-android


### PR DESCRIPTION
**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

This PR prepares the SDK for 2.0.4 version release.  Here are some misc. updates also included in this PR:

- Fix flaky attachments test where hanging child job causes test failure
- Removing `onParticipantActive/Inactive` from README as it is not supported

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

YES

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session

