### PR TITLE
fix: add transfer events to transcript and comprehensive event logging

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -322,6 +322,11 @@ class WebSocketManagerImpl @Inject constructor(
                             handleTyping(jsonObject, jsonString)
                         ContentType.ENDED ->
                             handleChatEnded(jsonObject, jsonString)
+                        ContentType.TRANSFER_SUCCEEDED, ContentType.TRANSFER_FAILED,
+                        ContentType.PARTICIPANT_IDLE, ContentType.PARTICIPANT_RETURNED,
+                        ContentType.PARTICIPANT_INVITED, ContentType.AUTO_DISCONNECTION,
+                        ContentType.CHAT_REHYDRATED ->
+                            handleCommonChatEvent(jsonObject, jsonString)
                         else -> {
                             SDKLogger.logger.logWarn{"WebSocket: Unknown event: $contentType"}
                             null
@@ -477,6 +482,26 @@ class WebSocketManagerImpl @Inject constructor(
                 SDKLogger.logger.logDebug{"WebSocket: Emitted ChatEvent: $event for ContentType: ${type.type}"}
             }
         }
+    }
+
+    private fun handleCommonChatEvent(innerJson: JSONObject, rawData: String): TranscriptItem {
+        val contentType = innerJson.optString("ContentType", "")
+        val participantRole = innerJson.optString("ParticipantRole", "")
+        val time = innerJson.optString("AbsoluteTime", "")
+        val displayName = innerJson.optString("DisplayName", "")
+        val messageId = innerJson.optString("Id", "")
+        val text = innerJson.optString("Content", "")
+
+        return Event(
+            participant = participantRole,
+            text = text,
+            displayName = displayName,
+            eventDirection = MessageDirection.COMMON,
+            timeStamp = time,
+            contentType = contentType,
+            id = messageId,
+            serializedContent = rawData
+        )
     }
 
     private suspend fun handleMessage(innerJson: JSONObject, rawData: String): TranscriptItem {

--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/network/WebSocketManager.kt
@@ -326,7 +326,7 @@ class WebSocketManagerImpl @Inject constructor(
                         ContentType.PARTICIPANT_IDLE, ContentType.PARTICIPANT_RETURNED,
                         ContentType.PARTICIPANT_INVITED, ContentType.AUTO_DISCONNECTION,
                         ContentType.CHAT_REHYDRATED ->
-                            handleCommonChatEvent(jsonObject, jsonString)
+                            createCommonEvent(jsonObject, jsonString)
                         else -> {
                             SDKLogger.logger.logWarn{"WebSocket: Unknown event: $contentType"}
                             null
@@ -446,18 +446,7 @@ class WebSocketManagerImpl @Inject constructor(
                 ContentType.LEFT,
                 ContentType.ENDED,
                 ContentType.TRANSFER_SUCCEEDED,
-                ContentType.TRANSFER_FAILED -> {
-                    Event(
-                        participant = jsonObject.optString("ParticipantRole"),
-                        text = jsonObject.optString("Content"),
-                        displayName = jsonObject.optString("DisplayName"),
-                        eventDirection = MessageDirection.COMMON,
-                        timeStamp = jsonObject.optString("AbsoluteTime"),
-                        contentType = jsonObject.optString("ContentType"),
-                        id = jsonObject.optString("Id"),
-                        serializedContent = rawData
-                    )
-                }
+                ContentType.TRANSFER_FAILED -> createCommonEvent(jsonObject, rawData)
                 else -> null
             }
             
@@ -484,22 +473,15 @@ class WebSocketManagerImpl @Inject constructor(
         }
     }
 
-    private fun handleCommonChatEvent(innerJson: JSONObject, rawData: String): TranscriptItem {
-        val contentType = innerJson.optString("ContentType", "")
-        val participantRole = innerJson.optString("ParticipantRole", "")
-        val time = innerJson.optString("AbsoluteTime", "")
-        val displayName = innerJson.optString("DisplayName", "")
-        val messageId = innerJson.optString("Id", "")
-        val text = innerJson.optString("Content", "")
-
+    private fun createCommonEvent(jsonObject: JSONObject, rawData: String): Event {
         return Event(
-            participant = participantRole,
-            text = text,
-            displayName = displayName,
+            participant = jsonObject.optString("ParticipantRole", ""),
+            text = jsonObject.optString("Content", ""),
+            displayName = jsonObject.optString("DisplayName", ""),
             eventDirection = MessageDirection.COMMON,
-            timeStamp = time,
-            contentType = contentType,
-            id = messageId,
+            timeStamp = jsonObject.optString("AbsoluteTime", ""),
+            contentType = jsonObject.optString("ContentType", ""),
+            id = jsonObject.optString("Id", ""),
             serializedContent = rawData
         )
     }


### PR DESCRIPTION

Fixes issue where transfer events were triggering callbacks but not appearing in transcript.

**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
Test e2e the transcript failed events

