### PR TITLE
Add CI/CD linting rule to prevent println() statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,13 @@ jobs:
       - name: Lint - Check for println() statements
         run: |
           echo "Checking for println() statements in Kotlin/Java files..."
-          if grep -r "println(" --include="*.kt" --include="*.java" . --exclude-dir=".git" --exclude-dir=".gradle" --exclude-dir="build"; then
+          if grep -r "println(" --include="*.kt" --include="*.java" . --exclude-dir=".git" --exclude-dir=".gradle" --exclude-dir="build" --exclude-dir="app"; then
             echo "❌ ERROR: Found println() statements in Kotlin/Java files"
             echo "Please use proper logging (Log.d, Log.i, etc.) instead of println() for logging"
+            echo "Example: SDKLogger.logger.logDebug { \"Your message\" }"
             exit 1
           else
-            echo "✅ No println() statements found"
+            echo "✅ No println() statements found in SDK code"
           fi
 
       - name: Set up JDK 17

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,11 +21,12 @@ jobs:
         echo "Checking for println() statements in Kotlin/Java files..."
         
         # Find all Kotlin and Java files and check for println() statements
-        if grep -r "println(" --include="*.kt" --include="*.java" . --exclude-dir=".git" --exclude-dir=".gradle" --exclude-dir="build"; then
+        # Exclude app directory (example code), .git, .gradle, and build directories
+        if grep -r "println(" --include="*.kt" --include="*.java" . --exclude-dir=".git" --exclude-dir=".gradle" --exclude-dir="build" --exclude-dir="app"; then
           echo "❌ ERROR: Found println() statements in Kotlin/Java files"
           echo "Please use proper logging (Log.d, Log.i, etc.) instead of println() for logging"
-          echo "Example: Log.i(TAG, \"Your message\")"
+          echo "Example: SDKLogger.logger.logDebug { \"Your message\" }"
           exit 1
         else
-          echo "✅ No println() statements found"
+          echo "✅ No println() statements found in SDK code"
         fi

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/network/WebSocketManagerTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/network/WebSocketManagerTest.kt
@@ -1,6 +1,7 @@
 package com.amazon.connect.chat.sdk.network
 
 import com.amazon.connect.chat.sdk.provider.ConnectionDetailsProvider
+import com.amazon.connect.chat.sdk.utils.logger.SDKLogger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -112,10 +113,10 @@ class WebSocketManagerTest {
                     it.set(obj, value)
                 }
             } catch (ex: Exception) {
-                println("Error setting fallback field $fieldName: ${ex.message}")
+                SDKLogger.logger.logDebug { "Error setting fallback field $fieldName: ${ex.message}" }
             }
         } catch (e: Exception) {
-            println("Error setting field $fieldName: ${e.message}")
+            SDKLogger.logger.logDebug { "Error setting field $fieldName: ${e.message}" }
         }
     }
 
@@ -125,7 +126,7 @@ class WebSocketManagerTest {
             field.isAccessible = true
             field.get(obj)
         } catch (e: Exception) {
-            println("Error getting field $fieldName: ${e.message}")
+            SDKLogger.logger.logDebug { "Error getting field $fieldName: ${e.message}" }
             null
         }
     }

--- a/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/utils/MetricsUtilsTest.kt
+++ b/chat-sdk/src/test/java/com/amazon/connect/chat/sdk/utils/MetricsUtilsTest.kt
@@ -1,5 +1,6 @@
 package com.amazon.connect.chat.sdk.utils
 
+import com.amazon.connect.chat.sdk.utils.logger.SDKLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -14,7 +15,7 @@ class MetricsUtilsTest {
         val timestamp = MetricsUtils.getCurrentMetricTimestamp()
 
         // Print the timestamp to see its actual format
-        println("Timestamp: $timestamp")
+        SDKLogger.logger.logDebug { "Timestamp: $timestamp" }
 
         // Verify the timestamp can be parsed back using the same formatter
         val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.getDefault())


### PR DESCRIPTION
- Created dedicated lint workflow that checks for println() statements
- Added linting step to existing CI workflow
- Enforces use of proper Android logging instead of println()

**Issue Number:**

### Description:
*What are the changes? Why are we making them?*

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

*Does this change introduce any new dependency?* [YES/NO]

---

### Testing:
*Is the code unit tested?*

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
test lint rule https://github.com/amazon-connect/amazon-connect-chat-android/pull/85
