### PR TITLE
Setting isChatActive state to false on dummy end

### DIFF
--- a/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
+++ b/chat-sdk/src/main/java/com/amazon/connect/chat/sdk/repository/ChatService.kt
@@ -688,6 +688,7 @@ class ChatServiceImpl @Inject constructor(
                     val endedEvent = TranscriptItemUtils.createDummyEndedEvent()
                     updateTranscriptDict(endedEvent)
                     _eventPublisher.emit(ChatEventPayload(ChatEvent.ChatEnded))
+                    connectionDetailsProvider.setChatSessionState(false)
                 }
                 SDKLogger.logger.logError { "CreateParticipantConnection failed: $error" }
             }


### PR DESCRIPTION
**Issue Number:**

### Description:

We enter the "dummy end" scenario where the chat is ended by the back-end while the client's WebSocket is disconnected.  WebSocket is disconnected on network disruptions, app backgrounds, locked phone, etc.

When the client returns and attempts to re-connect to its previous chat session, it will receive a 403 forbidden because the chat has already ended on the back-end.  When we receive this 403 error, we assume the chat has ended and execute the "dummy end" scenario.

This PR makes a fix that sets the `isChatActive` boolean to `false` when this happens.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* [YES/NO]

NO

*Does this change introduce any new dependency?* [YES/NO]

NO

---

### Testing:
*Is the code unit tested?*

NO

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

*List manual testing steps:*
 - Add Steps below: 

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

