### PR TITLE
chat-sdk: include consumer proguard rules

### DIFF
--- a/chat-sdk/build.gradle.kts
+++ b/chat-sdk/build.gradle.kts
@@ -28,6 +28,7 @@ android {
             useSupportLibrary = true
         }
         buildConfigField("String", "SDK_VERSION", "\"${versionProperties["sdkVersion"]}\"")
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     buildTypes {

--- a/chat-sdk/consumer-rules.pro
+++ b/chat-sdk/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Keep Retrofit services that are created by reflection
+-keep class com.amazon.connect.chat.sdk.network.api.MetricsInterface { *; }
+-keep class com.amazon.connect.chat.sdk.network.api.AttachmentsInterface { *; }


### PR DESCRIPTION
### Description:

Include consumer Proguard rules so that applications can build with R8 and minification enabled without the risk of trimming used classes. Includes two Retrofit interfaces that are accessed by reflection.

---

### Functional backward compatibility:
*Does this change introduce backwards incompatible changes?* No

*Does this change introduce any new dependency?* No

---

### Testing:
*Is the code unit tested?* N/A

*Have you tested the changes with a sample UI (e.g. [Android Mobile Chat Example](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/tree/master/mobileChatExamples/androidChatExample))?*

Tested a local publication of the chat SDK integrated into a release build of the Trainline app. The Travel Assistant feature uses it.

*List manual testing steps:*
 - All scenarios below except for the attachment ones successfully tested.

Here are a list of manual test cases to run through:
* Initiating chat and connecting with an agent
* Retrieving transcript
* Disconnecting from chat
* Sending a message to the agent
    * See typing bubbles on agent side
    * See read/delivered receipt on client side
    * Receiving a message from the agent
    * See typing bubbles on client side
    * See read/delivered receipt on agent side
    * Sending an attachment to the agent (try .txt, .pdf, .jpg)
    * Preview the attachment on click
    * Receiving an attachment from the agent
    * Preview the attachment on click
* Close the application (Without ending chat) → open app again → Start chat → Should Retrieve transcript from a previous chat session
* Quick Connect transfer failed should show the transfer failed event in the transcript

